### PR TITLE
Add support for vm_enter_scope and vm_exit_scope

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,8 @@
-pub mod ids;
+mod ids;
 mod memory;
 mod memory_segments;
 mod relocatable;
+mod scope_manager;
 mod utils;
 mod vm_core;
 

--- a/src/scope_manager.rs
+++ b/src/scope_manager.rs
@@ -1,0 +1,32 @@
+use std::collections::HashMap;
+
+use pyo3::{pyclass, pymethods, PyObject};
+
+#[pyclass(unsendable)]
+pub struct PyScopeManager {
+    exit: i32,
+    enter: Vec<HashMap<String, PyObject>>,
+}
+
+impl PyScopeManager {
+    pub fn new() -> PyScopeManager {
+        PyScopeManager {
+            exit: 0,
+            enter: Vec::new(),
+        }
+    }
+}
+
+#[pymethods]
+impl PyScopeManager {
+    pub fn enter_scope(&mut self, variables: Option<HashMap<String, PyObject>>) {
+        match variables {
+            Some(variables) => self.enter.push(variables),
+            None => self.enter.push(HashMap::new()),
+        }
+    }
+
+    pub fn exit_scope(&mut self) {
+        self.exit += 1
+    }
+}

--- a/src/scope_manager.rs
+++ b/src/scope_manager.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use pyo3::{pyclass, pymethods, PyObject};
+use pyo3::{pyclass, pyfunction, pymethods, types::PyModule, PyObject, PyResult};
 
 #[pyclass(unsendable)]
 pub struct PyScopeManager {
@@ -29,4 +29,23 @@ impl PyScopeManager {
     pub fn exit_scope(&mut self) {
         self.exit += 1
     }
+}
+
+#[pyfunction]
+#[pyo3(pass_module)]
+pub fn vm_enter_scope(
+    module: &PyModule,
+    variables: Option<HashMap<String, PyObject>>,
+) -> PyResult<()> {
+    let scope_manager = module.getattr("scope")?;
+    scope_manager.call_method1("enter_scope", (variables,))?;
+    Ok(())
+}
+
+#[pyfunction]
+#[pyo3(pass_module)]
+pub fn vm_exit_scope(module: &PyModule) -> PyResult<()> {
+    let scope_manager = module.getattr("scope")?;
+    scope_manager.call_method0("exit_scope")?;
+    Ok(())
 }

--- a/src/scope_manager.rs
+++ b/src/scope_manager.rs
@@ -3,49 +3,42 @@ use std::collections::HashMap;
 use pyo3::{pyclass, pyfunction, pymethods, types::PyModule, PyObject, PyResult};
 
 #[pyclass(unsendable)]
-pub struct PyScopeManager {
-    exit: i32,
-    enter: Vec<HashMap<String, PyObject>>,
+pub struct PyEnterScope {
+    new_scopes: Vec<HashMap<String, PyObject>>,
 }
 
-impl PyScopeManager {
-    pub fn new() -> PyScopeManager {
-        PyScopeManager {
-            exit: 0,
-            enter: Vec::new(),
+impl PyEnterScope {
+    pub fn new() -> PyEnterScope {
+        PyEnterScope {
+            new_scopes: Vec::<HashMap<String, PyObject>>::new(),
         }
     }
 }
 
 #[pymethods]
-impl PyScopeManager {
-    pub fn enter_scope(&mut self, variables: Option<HashMap<String, PyObject>>) {
+impl PyEnterScope {
+    pub fn __call__(&mut self, variables: Option<HashMap<String, PyObject>>) {
         match variables {
-            Some(variables) => self.enter.push(variables),
-            None => self.enter.push(HashMap::new()),
+            Some(variables) => self.new_scopes.push(variables),
+            None => self.new_scopes.push(HashMap::new()),
         }
     }
+}
 
-    pub fn exit_scope(&mut self) {
-        self.exit += 1
+#[pyclass(unsendable)]
+pub struct PyExitScope {
+    num: i32,
+}
+
+impl PyExitScope {
+    pub fn new() -> PyExitScope {
+        PyExitScope { num: 0 }
     }
 }
 
-#[pyfunction]
-#[pyo3(pass_module)]
-pub fn vm_enter_scope(
-    module: &PyModule,
-    variables: Option<HashMap<String, PyObject>>,
-) -> PyResult<()> {
-    let scope_manager = module.getattr("scope")?;
-    scope_manager.call_method1("enter_scope", (variables,))?;
-    Ok(())
-}
-
-#[pyfunction]
-#[pyo3(pass_module)]
-pub fn vm_exit_scope(module: &PyModule) -> PyResult<()> {
-    let scope_manager = module.getattr("scope")?;
-    scope_manager.call_method0("exit_scope")?;
-    Ok(())
+#[pymethods]
+impl PyExitScope {
+    pub fn __call__(&mut self) {
+        self.num += 1
+    }
 }

--- a/src/vm_core.rs
+++ b/src/vm_core.rs
@@ -28,11 +28,7 @@ impl PyVM {
     #[new]
     pub fn new(prime: BigInt, trace_enabled: bool) -> PyVM {
         PyVM {
-            vm: Rc::new(RefCell::new(VirtualMachine::new(
-                prime,
-                Vec::new(),
-                trace_enabled,
-            ))),
+            vm: Rc::new(RefCell::new(VirtualMachine::new(prime, trace_enabled))),
         }
     }
 }


### PR DESCRIPTION
- Add `PyEnterScope` and `PyExitScope`, each with its `__call__ `pymethod and update_scopes method
- Integrate them into `execute_hint`
- Add tests
Depends on #10 