### PR TITLE
Add implementation of cairo_run

### DIFF
--- a/cairo_programs/array_sum.cairo
+++ b/cairo_programs/array_sum.cairo
@@ -1,0 +1,37 @@
+%builtins output
+
+from starkware.cairo.common.alloc import alloc
+from starkware.cairo.common.serialize import serialize_word
+
+
+# Computes the sum of the memory elements at addresses:
+#   arr + 0, arr + 1, ..., arr + (size - 1).
+func array_sum(arr : felt*, size) -> (sum):
+    if size == 0:
+        return (sum=0)
+    end
+
+    # size is not zero.
+    let (sum_of_rest) = array_sum(arr=arr + 1, size=size - 1)
+    return (sum=[arr] + sum_of_rest)
+end
+
+func main{output_ptr : felt*}():
+    const ARRAY_SIZE = 3
+
+    # Allocate an array.
+    let (ptr) = alloc()
+
+    # Populate some values in the array.
+    assert [ptr] = 9
+    assert [ptr + 1] = 16
+    assert [ptr + 2] = 25
+
+    # Call array_sum to compute the sum of the elements.
+    let (sum) = array_sum(arr=ptr, size=ARRAY_SIZE)
+
+    # Write the sum to the program output.
+    serialize_word(sum)
+
+    return ()
+end

--- a/cairo_programs/array_sum.json
+++ b/cairo_programs/array_sum.json
@@ -1,0 +1,1370 @@
+{
+    "attributes": [],
+    "builtins": [
+        "output"
+    ],
+    "data": [
+        "0x40780017fff7fff",
+        "0x1",
+        "0x208b7fff7fff7ffe",
+        "0x400380007ffc7ffd",
+        "0x482680017ffc8000",
+        "0x1",
+        "0x208b7fff7fff7ffe",
+        "0x20780017fff7ffd",
+        "0x5",
+        "0x480680017fff8000",
+        "0x0",
+        "0x208b7fff7fff7ffe",
+        "0x482680017ffc8000",
+        "0x1",
+        "0x482680017ffd8000",
+        "0x800000000000011000000000000000000000000000000000000000000000000",
+        "0x1104800180018000",
+        "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffff8",
+        "0x480280007ffc8000",
+        "0x48307ffe7fff8000",
+        "0x208b7fff7fff7ffe",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffec",
+        "0x480680017fff8000",
+        "0x9",
+        "0x400080007ffe7fff",
+        "0x480680017fff8000",
+        "0x10",
+        "0x400080017ffd7fff",
+        "0x480680017fff8000",
+        "0x19",
+        "0x400080027ffc7fff",
+        "0x48127ffc7fff8000",
+        "0x480680017fff8000",
+        "0x3",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffe5",
+        "0x480a7ffd7fff8000",
+        "0x48127ffe7fff8000",
+        "0x1104800180018000",
+        "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffdd",
+        "0x208b7fff7fff7ffe"
+    ],
+    "debug_info": {
+        "file_contents": {},
+        "instruction_locations": {
+            "0": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.alloc",
+                    "starkware.cairo.common.alloc.alloc"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "reference_ids": {}
+                },
+                "hints": [
+                    {
+                        "location": {
+                            "end_col": 38,
+                            "end_line": 3,
+                            "input_file": {
+                                "filename": "/Users/lambda/cairo_venv/lib/python3.9/site-packages/starkware/cairo/common/alloc.cairo"
+                            },
+                            "start_col": 5,
+                            "start_line": 3
+                        },
+                        "n_prefix_newlines": 0
+                    }
+                ],
+                "inst": {
+                    "end_col": 12,
+                    "end_line": 4,
+                    "input_file": {
+                        "filename": "/Users/lambda/cairo_venv/lib/python3.9/site-packages/starkware/cairo/common/alloc.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 4
+                }
+            },
+            "2": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.alloc",
+                    "starkware.cairo.common.alloc.alloc"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 1
+                    },
+                    "reference_ids": {}
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 39,
+                    "end_line": 5,
+                    "input_file": {
+                        "filename": "/Users/lambda/cairo_venv/lib/python3.9/site-packages/starkware/cairo/common/alloc.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 5
+                }
+            },
+            "3": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.serialize",
+                    "starkware.cairo.common.serialize.serialize_word"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.serialize.serialize_word.output_ptr": 1,
+                        "starkware.cairo.common.serialize.serialize_word.word": 0
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 31,
+                    "end_line": 3,
+                    "input_file": {
+                        "filename": "/Users/lambda/cairo_venv/lib/python3.9/site-packages/starkware/cairo/common/serialize.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 3
+                }
+            },
+            "4": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.serialize",
+                    "starkware.cairo.common.serialize.serialize_word"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.serialize.serialize_word.output_ptr": 2,
+                        "starkware.cairo.common.serialize.serialize_word.word": 0
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 36,
+                    "end_line": 4,
+                    "input_file": {
+                        "filename": "/Users/lambda/cairo_venv/lib/python3.9/site-packages/starkware/cairo/common/serialize.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 39,
+                            "end_line": 2,
+                            "input_file": {
+                                "filename": "/Users/lambda/cairo_venv/lib/python3.9/site-packages/starkware/cairo/common/serialize.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 14,
+                                    "end_line": 5,
+                                    "input_file": {
+                                        "filename": "/Users/lambda/cairo_venv/lib/python3.9/site-packages/starkware/cairo/common/serialize.cairo"
+                                    },
+                                    "start_col": 5,
+                                    "start_line": 5
+                                },
+                                "While trying to retrieve the implicit argument 'output_ptr' in:"
+                            ],
+                            "start_col": 21,
+                            "start_line": 2
+                        },
+                        "While expanding the reference 'output_ptr' in:"
+                    ],
+                    "start_col": 22,
+                    "start_line": 4
+                }
+            },
+            "6": {
+                "accessible_scopes": [
+                    "starkware.cairo.common.serialize",
+                    "starkware.cairo.common.serialize.serialize_word"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "starkware.cairo.common.serialize.serialize_word.output_ptr": 2,
+                        "starkware.cairo.common.serialize.serialize_word.word": 0
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 14,
+                    "end_line": 5,
+                    "input_file": {
+                        "filename": "/Users/lambda/cairo_venv/lib/python3.9/site-packages/starkware/cairo/common/serialize.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 5
+                }
+            },
+            "7": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.array_sum"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.array_sum.arr": 3,
+                        "__main__.array_sum.size": 4
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 7,
+                    "end_line": 10,
+                    "input_file": {
+                        "filename": "cairo_programs/array_sum.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 10
+                }
+            },
+            "9": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.array_sum"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.array_sum.arr": 3,
+                        "__main__.array_sum.size": 4
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 22,
+                    "end_line": 11,
+                    "input_file": {
+                        "filename": "cairo_programs/array_sum.cairo"
+                    },
+                    "start_col": 21,
+                    "start_line": 11
+                }
+            },
+            "11": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.array_sum"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.array_sum.arr": 3,
+                        "__main__.array_sum.size": 4
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 23,
+                    "end_line": 11,
+                    "input_file": {
+                        "filename": "cairo_programs/array_sum.cairo"
+                    },
+                    "start_col": 9,
+                    "start_line": 11
+                }
+            },
+            "12": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.array_sum"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.array_sum.arr": 3,
+                        "__main__.array_sum.size": 4
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 46,
+                    "end_line": 15,
+                    "input_file": {
+                        "filename": "cairo_programs/array_sum.cairo"
+                    },
+                    "start_col": 39,
+                    "start_line": 15
+                }
+            },
+            "14": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.array_sum"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.array_sum.arr": 3,
+                        "__main__.array_sum.size": 4
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 61,
+                    "end_line": 15,
+                    "input_file": {
+                        "filename": "cairo_programs/array_sum.cairo"
+                    },
+                    "start_col": 53,
+                    "start_line": 15
+                }
+            },
+            "16": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.array_sum"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "__main__.array_sum.arr": 3,
+                        "__main__.array_sum.size": 4
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 62,
+                    "end_line": 15,
+                    "input_file": {
+                        "filename": "cairo_programs/array_sum.cairo"
+                    },
+                    "start_col": 25,
+                    "start_line": 15
+                }
+            },
+            "18": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.array_sum"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 3,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.array_sum.arr": 3,
+                        "__main__.array_sum.size": 4,
+                        "__main__.array_sum.sum_of_rest": 5
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 22,
+                    "end_line": 16,
+                    "input_file": {
+                        "filename": "cairo_programs/array_sum.cairo"
+                    },
+                    "start_col": 17,
+                    "start_line": 16
+                }
+            },
+            "19": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.array_sum"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 3,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.array_sum.__temp0": 6,
+                        "__main__.array_sum.arr": 3,
+                        "__main__.array_sum.size": 4,
+                        "__main__.array_sum.sum_of_rest": 5
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 36,
+                    "end_line": 16,
+                    "input_file": {
+                        "filename": "cairo_programs/array_sum.cairo"
+                    },
+                    "start_col": 17,
+                    "start_line": 16
+                }
+            },
+            "20": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.array_sum"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 3,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "__main__.array_sum.__temp0": 6,
+                        "__main__.array_sum.arr": 3,
+                        "__main__.array_sum.size": 4,
+                        "__main__.array_sum.sum_of_rest": 5
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 37,
+                    "end_line": 16,
+                    "input_file": {
+                        "filename": "cairo_programs/array_sum.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 16
+                }
+            },
+            "21": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.main.output_ptr": 7
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 24,
+                    "end_line": 23,
+                    "input_file": {
+                        "filename": "cairo_programs/array_sum.cairo"
+                    },
+                    "start_col": 17,
+                    "start_line": 23
+                }
+            },
+            "23": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 3
+                    },
+                    "reference_ids": {
+                        "__main__.main.output_ptr": 7,
+                        "__main__.main.ptr": 8
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 21,
+                    "end_line": 26,
+                    "input_file": {
+                        "filename": "cairo_programs/array_sum.cairo"
+                    },
+                    "start_col": 20,
+                    "start_line": 26
+                }
+            },
+            "25": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 4
+                    },
+                    "reference_ids": {
+                        "__main__.main.__temp1": 9,
+                        "__main__.main.output_ptr": 7,
+                        "__main__.main.ptr": 8
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 21,
+                    "end_line": 26,
+                    "input_file": {
+                        "filename": "cairo_programs/array_sum.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 26
+                }
+            },
+            "26": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 4
+                    },
+                    "reference_ids": {
+                        "__main__.main.__temp1": 9,
+                        "__main__.main.output_ptr": 7,
+                        "__main__.main.ptr": 8
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 26,
+                    "end_line": 27,
+                    "input_file": {
+                        "filename": "cairo_programs/array_sum.cairo"
+                    },
+                    "start_col": 24,
+                    "start_line": 27
+                }
+            },
+            "28": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 5
+                    },
+                    "reference_ids": {
+                        "__main__.main.__temp1": 9,
+                        "__main__.main.__temp2": 10,
+                        "__main__.main.output_ptr": 7,
+                        "__main__.main.ptr": 8
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 26,
+                    "end_line": 27,
+                    "input_file": {
+                        "filename": "cairo_programs/array_sum.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 27
+                }
+            },
+            "29": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 5
+                    },
+                    "reference_ids": {
+                        "__main__.main.__temp1": 9,
+                        "__main__.main.__temp2": 10,
+                        "__main__.main.output_ptr": 7,
+                        "__main__.main.ptr": 8
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 26,
+                    "end_line": 28,
+                    "input_file": {
+                        "filename": "cairo_programs/array_sum.cairo"
+                    },
+                    "start_col": 24,
+                    "start_line": 28
+                }
+            },
+            "31": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 6
+                    },
+                    "reference_ids": {
+                        "__main__.main.__temp1": 9,
+                        "__main__.main.__temp2": 10,
+                        "__main__.main.__temp3": 11,
+                        "__main__.main.output_ptr": 7,
+                        "__main__.main.ptr": 8
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 26,
+                    "end_line": 28,
+                    "input_file": {
+                        "filename": "cairo_programs/array_sum.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 28
+                }
+            },
+            "32": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 6
+                    },
+                    "reference_ids": {
+                        "__main__.main.__temp1": 9,
+                        "__main__.main.__temp2": 10,
+                        "__main__.main.__temp3": 11,
+                        "__main__.main.output_ptr": 7,
+                        "__main__.main.ptr": 8
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 13,
+                    "end_line": 23,
+                    "input_file": {
+                        "filename": "cairo_programs/array_sum.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 34,
+                            "end_line": 31,
+                            "input_file": {
+                                "filename": "cairo_programs/array_sum.cairo"
+                            },
+                            "start_col": 31,
+                            "start_line": 31
+                        },
+                        "While expanding the reference 'ptr' in:"
+                    ],
+                    "start_col": 10,
+                    "start_line": 23
+                }
+            },
+            "33": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 7
+                    },
+                    "reference_ids": {
+                        "__main__.main.__temp1": 9,
+                        "__main__.main.__temp2": 10,
+                        "__main__.main.__temp3": 11,
+                        "__main__.main.output_ptr": 7,
+                        "__main__.main.ptr": 8
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 51,
+                    "end_line": 31,
+                    "input_file": {
+                        "filename": "cairo_programs/array_sum.cairo"
+                    },
+                    "start_col": 41,
+                    "start_line": 31
+                }
+            },
+            "35": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 4,
+                        "offset": 8
+                    },
+                    "reference_ids": {
+                        "__main__.main.__temp1": 9,
+                        "__main__.main.__temp2": 10,
+                        "__main__.main.__temp3": 11,
+                        "__main__.main.output_ptr": 7,
+                        "__main__.main.ptr": 8
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 52,
+                    "end_line": 31,
+                    "input_file": {
+                        "filename": "cairo_programs/array_sum.cairo"
+                    },
+                    "start_col": 17,
+                    "start_line": 31
+                }
+            },
+            "37": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 5,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.main.__temp1": 9,
+                        "__main__.main.__temp2": 10,
+                        "__main__.main.__temp3": 11,
+                        "__main__.main.output_ptr": 7,
+                        "__main__.main.ptr": 8,
+                        "__main__.main.sum": 12
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 29,
+                    "end_line": 19,
+                    "input_file": {
+                        "filename": "cairo_programs/array_sum.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 39,
+                            "end_line": 2,
+                            "input_file": {
+                                "filename": "/Users/lambda/cairo_venv/lib/python3.9/site-packages/starkware/cairo/common/serialize.cairo"
+                            },
+                            "parent_location": [
+                                {
+                                    "end_col": 24,
+                                    "end_line": 34,
+                                    "input_file": {
+                                        "filename": "cairo_programs/array_sum.cairo"
+                                    },
+                                    "start_col": 5,
+                                    "start_line": 34
+                                },
+                                "While trying to retrieve the implicit argument 'output_ptr' in:"
+                            ],
+                            "start_col": 21,
+                            "start_line": 2
+                        },
+                        "While expanding the reference 'output_ptr' in:"
+                    ],
+                    "start_col": 11,
+                    "start_line": 19
+                }
+            },
+            "38": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 5,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.main.__temp1": 9,
+                        "__main__.main.__temp2": 10,
+                        "__main__.main.__temp3": 11,
+                        "__main__.main.output_ptr": 7,
+                        "__main__.main.ptr": 8,
+                        "__main__.main.sum": 12
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 13,
+                    "end_line": 31,
+                    "input_file": {
+                        "filename": "cairo_programs/array_sum.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 23,
+                            "end_line": 34,
+                            "input_file": {
+                                "filename": "cairo_programs/array_sum.cairo"
+                            },
+                            "start_col": 20,
+                            "start_line": 34
+                        },
+                        "While expanding the reference 'sum' in:"
+                    ],
+                    "start_col": 10,
+                    "start_line": 31
+                }
+            },
+            "39": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 5,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "__main__.main.__temp1": 9,
+                        "__main__.main.__temp2": 10,
+                        "__main__.main.__temp3": 11,
+                        "__main__.main.output_ptr": 7,
+                        "__main__.main.ptr": 8,
+                        "__main__.main.sum": 12
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 24,
+                    "end_line": 34,
+                    "input_file": {
+                        "filename": "cairo_programs/array_sum.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 34
+                }
+            },
+            "41": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 5,
+                        "offset": 5
+                    },
+                    "reference_ids": {
+                        "__main__.main.__temp1": 9,
+                        "__main__.main.__temp2": 10,
+                        "__main__.main.__temp3": 11,
+                        "__main__.main.output_ptr": 13,
+                        "__main__.main.ptr": 8,
+                        "__main__.main.sum": 12
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 14,
+                    "end_line": 36,
+                    "input_file": {
+                        "filename": "cairo_programs/array_sum.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 36
+                }
+            }
+        }
+    },
+    "hints": {
+        "0": [
+            {
+                "accessible_scopes": [
+                    "starkware.cairo.common.alloc",
+                    "starkware.cairo.common.alloc.alloc"
+                ],
+                "code": "memory[ap] = segments.add()",
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "reference_ids": {}
+                }
+            }
+        ]
+    },
+    "identifiers": {
+        "__main__.alloc": {
+            "destination": "starkware.cairo.common.alloc.alloc",
+            "type": "alias"
+        },
+        "__main__.array_sum": {
+            "decorators": [],
+            "pc": 7,
+            "type": "function"
+        },
+        "__main__.array_sum.Args": {
+            "full_name": "__main__.array_sum.Args",
+            "members": {
+                "arr": {
+                    "cairo_type": "felt*",
+                    "offset": 0
+                },
+                "size": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 2,
+            "type": "struct"
+        },
+        "__main__.array_sum.ImplicitArgs": {
+            "full_name": "__main__.array_sum.ImplicitArgs",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "__main__.array_sum.Return": {
+            "cairo_type": "(sum : felt)",
+            "type": "type_definition"
+        },
+        "__main__.array_sum.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "__main__.array_sum.__temp0": {
+            "cairo_type": "felt",
+            "full_name": "__main__.array_sum.__temp0",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 3,
+                        "offset": 1
+                    },
+                    "pc": 19,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.array_sum.arr": {
+            "cairo_type": "felt*",
+            "full_name": "__main__.array_sum.arr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "pc": 7,
+                    "value": "[cast(fp + (-4), felt**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.array_sum.size": {
+            "cairo_type": "felt",
+            "full_name": "__main__.array_sum.size",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "pc": 7,
+                    "value": "[cast(fp + (-3), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.array_sum.sum_of_rest": {
+            "cairo_type": "felt",
+            "full_name": "__main__.array_sum.sum_of_rest",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 3,
+                        "offset": 0
+                    },
+                    "pc": 18,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main": {
+            "decorators": [],
+            "pc": 21,
+            "type": "function"
+        },
+        "__main__.main.ARRAY_SIZE": {
+            "type": "const",
+            "value": 3
+        },
+        "__main__.main.Args": {
+            "full_name": "__main__.main.Args",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "__main__.main.ImplicitArgs": {
+            "full_name": "__main__.main.ImplicitArgs",
+            "members": {
+                "output_ptr": {
+                    "cairo_type": "felt*",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "__main__.main.Return": {
+            "cairo_type": "()",
+            "type": "type_definition"
+        },
+        "__main__.main.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "__main__.main.__temp1": {
+            "cairo_type": "felt",
+            "full_name": "__main__.main.__temp1",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 4
+                    },
+                    "pc": 25,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main.__temp2": {
+            "cairo_type": "felt",
+            "full_name": "__main__.main.__temp2",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 5
+                    },
+                    "pc": 28,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main.__temp3": {
+            "cairo_type": "felt",
+            "full_name": "__main__.main.__temp3",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 6
+                    },
+                    "pc": 31,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main.output_ptr": {
+            "cairo_type": "felt*",
+            "full_name": "__main__.main.output_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 0
+                    },
+                    "pc": 21,
+                    "value": "[cast(fp + (-3), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 5,
+                        "offset": 5
+                    },
+                    "pc": 41,
+                    "value": "[cast(ap + (-1), felt**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main.ptr": {
+            "cairo_type": "felt*",
+            "full_name": "__main__.main.ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 3
+                    },
+                    "pc": 23,
+                    "value": "[cast(ap + (-1), felt**)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main.sum": {
+            "cairo_type": "felt",
+            "full_name": "__main__.main.sum",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 5,
+                        "offset": 0
+                    },
+                    "pc": 37,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.serialize_word": {
+            "destination": "starkware.cairo.common.serialize.serialize_word",
+            "type": "alias"
+        },
+        "starkware.cairo.common.alloc.alloc": {
+            "decorators": [],
+            "pc": 0,
+            "type": "function"
+        },
+        "starkware.cairo.common.alloc.alloc.Args": {
+            "full_name": "starkware.cairo.common.alloc.alloc.Args",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "starkware.cairo.common.alloc.alloc.ImplicitArgs": {
+            "full_name": "starkware.cairo.common.alloc.alloc.ImplicitArgs",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "starkware.cairo.common.alloc.alloc.Return": {
+            "cairo_type": "(ptr : felt*)",
+            "type": "type_definition"
+        },
+        "starkware.cairo.common.alloc.alloc.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "starkware.cairo.common.serialize.serialize_word": {
+            "decorators": [],
+            "pc": 3,
+            "type": "function"
+        },
+        "starkware.cairo.common.serialize.serialize_word.Args": {
+            "full_name": "starkware.cairo.common.serialize.serialize_word.Args",
+            "members": {
+                "word": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "starkware.cairo.common.serialize.serialize_word.ImplicitArgs": {
+            "full_name": "starkware.cairo.common.serialize.serialize_word.ImplicitArgs",
+            "members": {
+                "output_ptr": {
+                    "cairo_type": "felt*",
+                    "offset": 0
+                }
+            },
+            "size": 1,
+            "type": "struct"
+        },
+        "starkware.cairo.common.serialize.serialize_word.Return": {
+            "cairo_type": "()",
+            "type": "type_definition"
+        },
+        "starkware.cairo.common.serialize.serialize_word.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "starkware.cairo.common.serialize.serialize_word.output_ptr": {
+            "cairo_type": "felt*",
+            "full_name": "starkware.cairo.common.serialize.serialize_word.output_ptr",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "pc": 3,
+                    "value": "[cast(fp + (-4), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "pc": 4,
+                    "value": "cast([fp + (-4)] + 1, felt*)"
+                }
+            ],
+            "type": "reference"
+        },
+        "starkware.cairo.common.serialize.serialize_word.word": {
+            "cairo_type": "felt",
+            "full_name": "starkware.cairo.common.serialize.serialize_word.word",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "pc": 3,
+                    "value": "[cast(fp + (-3), felt*)]"
+                }
+            ],
+            "type": "reference"
+        }
+    },
+    "main_scope": "__main__",
+    "prime": "0x800000000000011000000000000000000000000000000000000000000000001",
+    "reference_manager": {
+        "references": [
+            {
+                "ap_tracking_data": {
+                    "group": 1,
+                    "offset": 0
+                },
+                "pc": 3,
+                "value": "[cast(fp + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 1,
+                    "offset": 0
+                },
+                "pc": 3,
+                "value": "[cast(fp + (-4), felt**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 1,
+                    "offset": 0
+                },
+                "pc": 4,
+                "value": "cast([fp + (-4)] + 1, felt*)"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 2,
+                    "offset": 0
+                },
+                "pc": 7,
+                "value": "[cast(fp + (-4), felt**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 2,
+                    "offset": 0
+                },
+                "pc": 7,
+                "value": "[cast(fp + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 3,
+                    "offset": 0
+                },
+                "pc": 18,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 3,
+                    "offset": 1
+                },
+                "pc": 19,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 0
+                },
+                "pc": 21,
+                "value": "[cast(fp + (-3), felt**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 3
+                },
+                "pc": 23,
+                "value": "[cast(ap + (-1), felt**)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 4
+                },
+                "pc": 25,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 5
+                },
+                "pc": 28,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 4,
+                    "offset": 6
+                },
+                "pc": 31,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 5,
+                    "offset": 0
+                },
+                "pc": 37,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 5,
+                    "offset": 5
+                },
+                "pc": 41,
+                "value": "[cast(ap + (-1), felt**)]"
+            }
+        ]
+    }
+}

--- a/cairo_programs/fibonacci.cairo
+++ b/cairo_programs/fibonacci.cairo
@@ -1,0 +1,18 @@
+func main():
+    # Call fib(1, 1, 10).
+    let result: felt = fib(1, 1, 10)
+
+    # Make sure the 10th Fibonacci number is 144.
+    assert result = 144
+    ret
+end
+
+func fib(first_element, second_element, n) -> (res : felt):
+    jmp fib_body if n != 0
+    tempvar result = second_element
+    return(second_element)
+
+    fib_body:
+    tempvar y = first_element + second_element
+    return fib(second_element, y, n - 1)
+end

--- a/cairo_programs/fibonacci.json
+++ b/cairo_programs/fibonacci.json
@@ -1,0 +1,716 @@
+{
+    "attributes": [],
+    "builtins": [],
+    "data": [
+        "0x480680017fff8000",
+        "0x1",
+        "0x480680017fff8000",
+        "0x1",
+        "0x480680017fff8000",
+        "0xa",
+        "0x1104800180018000",
+        "0x5",
+        "0x400680017fff7fff",
+        "0x90",
+        "0x208b7fff7fff7ffe",
+        "0x20780017fff7ffd",
+        "0x5",
+        "0x480a7ffc7fff8000",
+        "0x480a7ffc7fff8000",
+        "0x208b7fff7fff7ffe",
+        "0x482a7ffc7ffb8000",
+        "0x480a7ffc7fff8000",
+        "0x48127ffe7fff8000",
+        "0x482680017ffd8000",
+        "0x800000000000011000000000000000000000000000000000000000000000000",
+        "0x1104800180018000",
+        "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffff7",
+        "0x208b7fff7fff7ffe"
+    ],
+    "debug_info": {
+        "file_contents": {},
+        "instruction_locations": {
+            "0": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "reference_ids": {}
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 29,
+                    "end_line": 3,
+                    "input_file": {
+                        "filename": "cairo_programs/fibonacci.cairo"
+                    },
+                    "start_col": 28,
+                    "start_line": 3
+                }
+            },
+            "2": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 1
+                    },
+                    "reference_ids": {}
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 32,
+                    "end_line": 3,
+                    "input_file": {
+                        "filename": "cairo_programs/fibonacci.cairo"
+                    },
+                    "start_col": 31,
+                    "start_line": 3
+                }
+            },
+            "4": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 2
+                    },
+                    "reference_ids": {}
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 36,
+                    "end_line": 3,
+                    "input_file": {
+                        "filename": "cairo_programs/fibonacci.cairo"
+                    },
+                    "start_col": 34,
+                    "start_line": 3
+                }
+            },
+            "6": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 3
+                    },
+                    "reference_ids": {}
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 37,
+                    "end_line": 3,
+                    "input_file": {
+                        "filename": "cairo_programs/fibonacci.cairo"
+                    },
+                    "start_col": 24,
+                    "start_line": 3
+                }
+            },
+            "8": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.main.result": 0
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 24,
+                    "end_line": 6,
+                    "input_file": {
+                        "filename": "cairo_programs/fibonacci.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 6
+                }
+            },
+            "10": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.main.result": 0
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 8,
+                    "end_line": 7,
+                    "input_file": {
+                        "filename": "cairo_programs/fibonacci.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 7
+                }
+            },
+            "11": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.fib"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.fib.first_element": 1,
+                        "__main__.fib.n": 3,
+                        "__main__.fib.second_element": 2
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 27,
+                    "end_line": 11,
+                    "input_file": {
+                        "filename": "cairo_programs/fibonacci.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 11
+                }
+            },
+            "13": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.fib"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.fib.first_element": 1,
+                        "__main__.fib.n": 3,
+                        "__main__.fib.second_element": 2
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 39,
+                    "end_line": 10,
+                    "input_file": {
+                        "filename": "cairo_programs/fibonacci.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 36,
+                            "end_line": 12,
+                            "input_file": {
+                                "filename": "cairo_programs/fibonacci.cairo"
+                            },
+                            "start_col": 22,
+                            "start_line": 12
+                        },
+                        "While expanding the reference 'second_element' in:"
+                    ],
+                    "start_col": 25,
+                    "start_line": 10
+                }
+            },
+            "14": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.fib"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.fib.first_element": 1,
+                        "__main__.fib.n": 3,
+                        "__main__.fib.result": 4,
+                        "__main__.fib.second_element": 2
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 39,
+                    "end_line": 10,
+                    "input_file": {
+                        "filename": "cairo_programs/fibonacci.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 26,
+                            "end_line": 13,
+                            "input_file": {
+                                "filename": "cairo_programs/fibonacci.cairo"
+                            },
+                            "start_col": 12,
+                            "start_line": 13
+                        },
+                        "While expanding the reference 'second_element' in:"
+                    ],
+                    "start_col": 25,
+                    "start_line": 10
+                }
+            },
+            "15": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.fib"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "__main__.fib.first_element": 1,
+                        "__main__.fib.n": 3,
+                        "__main__.fib.result": 4,
+                        "__main__.fib.second_element": 2
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 27,
+                    "end_line": 13,
+                    "input_file": {
+                        "filename": "cairo_programs/fibonacci.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 13
+                }
+            },
+            "16": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.fib"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.fib.first_element": 1,
+                        "__main__.fib.n": 3,
+                        "__main__.fib.second_element": 2
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 47,
+                    "end_line": 16,
+                    "input_file": {
+                        "filename": "cairo_programs/fibonacci.cairo"
+                    },
+                    "start_col": 17,
+                    "start_line": 16
+                }
+            },
+            "17": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.fib"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 1
+                    },
+                    "reference_ids": {
+                        "__main__.fib.first_element": 1,
+                        "__main__.fib.n": 3,
+                        "__main__.fib.second_element": 2,
+                        "__main__.fib.y": 5
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 39,
+                    "end_line": 10,
+                    "input_file": {
+                        "filename": "cairo_programs/fibonacci.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 30,
+                            "end_line": 17,
+                            "input_file": {
+                                "filename": "cairo_programs/fibonacci.cairo"
+                            },
+                            "start_col": 16,
+                            "start_line": 17
+                        },
+                        "While expanding the reference 'second_element' in:"
+                    ],
+                    "start_col": 25,
+                    "start_line": 10
+                }
+            },
+            "18": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.fib"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 2
+                    },
+                    "reference_ids": {
+                        "__main__.fib.first_element": 1,
+                        "__main__.fib.n": 3,
+                        "__main__.fib.second_element": 2,
+                        "__main__.fib.y": 5
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 14,
+                    "end_line": 16,
+                    "input_file": {
+                        "filename": "cairo_programs/fibonacci.cairo"
+                    },
+                    "parent_location": [
+                        {
+                            "end_col": 33,
+                            "end_line": 17,
+                            "input_file": {
+                                "filename": "cairo_programs/fibonacci.cairo"
+                            },
+                            "start_col": 32,
+                            "start_line": 17
+                        },
+                        "While expanding the reference 'y' in:"
+                    ],
+                    "start_col": 13,
+                    "start_line": 16
+                }
+            },
+            "19": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.fib"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 3
+                    },
+                    "reference_ids": {
+                        "__main__.fib.first_element": 1,
+                        "__main__.fib.n": 3,
+                        "__main__.fib.second_element": 2,
+                        "__main__.fib.y": 5
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 40,
+                    "end_line": 17,
+                    "input_file": {
+                        "filename": "cairo_programs/fibonacci.cairo"
+                    },
+                    "start_col": 35,
+                    "start_line": 17
+                }
+            },
+            "21": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.fib"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 2,
+                        "offset": 4
+                    },
+                    "reference_ids": {
+                        "__main__.fib.first_element": 1,
+                        "__main__.fib.n": 3,
+                        "__main__.fib.second_element": 2,
+                        "__main__.fib.y": 5
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 41,
+                    "end_line": 17,
+                    "input_file": {
+                        "filename": "cairo_programs/fibonacci.cairo"
+                    },
+                    "start_col": 12,
+                    "start_line": 17
+                }
+            },
+            "23": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.fib"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 3,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.fib.first_element": 1,
+                        "__main__.fib.n": 3,
+                        "__main__.fib.second_element": 2,
+                        "__main__.fib.y": 5
+                    }
+                },
+                "hints": [],
+                "inst": {
+                    "end_col": 41,
+                    "end_line": 17,
+                    "input_file": {
+                        "filename": "cairo_programs/fibonacci.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 17
+                }
+            }
+        }
+    },
+    "hints": {},
+    "identifiers": {
+        "__main__.fib": {
+            "decorators": [],
+            "pc": 11,
+            "type": "function"
+        },
+        "__main__.fib.Args": {
+            "full_name": "__main__.fib.Args",
+            "members": {
+                "first_element": {
+                    "cairo_type": "felt",
+                    "offset": 0
+                },
+                "n": {
+                    "cairo_type": "felt",
+                    "offset": 2
+                },
+                "second_element": {
+                    "cairo_type": "felt",
+                    "offset": 1
+                }
+            },
+            "size": 3,
+            "type": "struct"
+        },
+        "__main__.fib.ImplicitArgs": {
+            "full_name": "__main__.fib.ImplicitArgs",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "__main__.fib.Return": {
+            "cairo_type": "(res : felt)",
+            "type": "type_definition"
+        },
+        "__main__.fib.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "__main__.fib.fib_body": {
+            "pc": 16,
+            "type": "label"
+        },
+        "__main__.fib.first_element": {
+            "cairo_type": "felt",
+            "full_name": "__main__.fib.first_element",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "pc": 11,
+                    "value": "[cast(fp + (-5), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.fib.n": {
+            "cairo_type": "felt",
+            "full_name": "__main__.fib.n",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "pc": 11,
+                    "value": "[cast(fp + (-3), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.fib.result": {
+            "cairo_type": "felt",
+            "full_name": "__main__.fib.result",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 2,
+                        "offset": 1
+                    },
+                    "pc": 14,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.fib.second_element": {
+            "cairo_type": "felt",
+            "full_name": "__main__.fib.second_element",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "pc": 11,
+                    "value": "[cast(fp + (-4), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.fib.y": {
+            "cairo_type": "felt",
+            "full_name": "__main__.fib.y",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 2,
+                        "offset": 1
+                    },
+                    "pc": 17,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main": {
+            "decorators": [],
+            "pc": 0,
+            "type": "function"
+        },
+        "__main__.main.Args": {
+            "full_name": "__main__.main.Args",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "__main__.main.ImplicitArgs": {
+            "full_name": "__main__.main.ImplicitArgs",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "__main__.main.Return": {
+            "cairo_type": "()",
+            "type": "type_definition"
+        },
+        "__main__.main.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "__main__.main.result": {
+            "cairo_type": "felt",
+            "full_name": "__main__.main.result",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "pc": 8,
+                    "value": "[cast(ap + (-1), felt*)]"
+                }
+            ],
+            "type": "reference"
+        }
+    },
+    "main_scope": "__main__",
+    "prime": "0x800000000000011000000000000000000000000000000000000000000000001",
+    "reference_manager": {
+        "references": [
+            {
+                "ap_tracking_data": {
+                    "group": 1,
+                    "offset": 0
+                },
+                "pc": 8,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 2,
+                    "offset": 0
+                },
+                "pc": 11,
+                "value": "[cast(fp + (-5), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 2,
+                    "offset": 0
+                },
+                "pc": 11,
+                "value": "[cast(fp + (-4), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 2,
+                    "offset": 0
+                },
+                "pc": 11,
+                "value": "[cast(fp + (-3), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 2,
+                    "offset": 1
+                },
+                "pc": 14,
+                "value": "[cast(ap + (-1), felt*)]"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 2,
+                    "offset": 1
+                },
+                "pc": 17,
+                "value": "[cast(ap + (-1), felt*)]"
+            }
+        ]
+    }
+}

--- a/cairo_programs/hint_print_vars.cairo
+++ b/cairo_programs/hint_print_vars.cairo
@@ -1,0 +1,13 @@
+func main():
+    let a : felt = 1
+    let b : felt = 2
+
+    %{
+        c = ids.a + ids.b
+        print("a: ", ids.a)
+        print("b: ", ids.b)
+        print("c: ", c)
+    %}
+
+    return ()
+end

--- a/cairo_programs/hint_print_vars.json
+++ b/cairo_programs/hint_print_vars.json
@@ -1,0 +1,151 @@
+{
+    "attributes": [],
+    "builtins": [],
+    "data": [
+        "0x208b7fff7fff7ffe"
+    ],
+    "debug_info": {
+        "file_contents": {},
+        "instruction_locations": {
+            "0": {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.main.a": 0,
+                        "__main__.main.b": 1
+                    }
+                },
+                "hints": [
+                    {
+                        "location": {
+                            "end_col": 7,
+                            "end_line": 10,
+                            "input_file": {
+                                "filename": "hint_print_vars.cairo"
+                            },
+                            "start_col": 5,
+                            "start_line": 5
+                        },
+                        "n_prefix_newlines": 1
+                    }
+                ],
+                "inst": {
+                    "end_col": 14,
+                    "end_line": 12,
+                    "input_file": {
+                        "filename": "hint_print_vars.cairo"
+                    },
+                    "start_col": 5,
+                    "start_line": 12
+                }
+            }
+        }
+    },
+    "hints": {
+        "0": [
+            {
+                "accessible_scopes": [
+                    "__main__",
+                    "__main__.main"
+                ],
+                "code": "c = ids.a + ids.b\nprint(\"a: \", ids.a)\nprint(\"b: \", ids.b)\nprint(\"c: \", c)",
+                "flow_tracking_data": {
+                    "ap_tracking": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "reference_ids": {
+                        "__main__.main.a": 0,
+                        "__main__.main.b": 1
+                    }
+                }
+            }
+        ]
+    },
+    "identifiers": {
+        "__main__.main": {
+            "decorators": [],
+            "pc": 0,
+            "type": "function"
+        },
+        "__main__.main.Args": {
+            "full_name": "__main__.main.Args",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "__main__.main.ImplicitArgs": {
+            "full_name": "__main__.main.ImplicitArgs",
+            "members": {},
+            "size": 0,
+            "type": "struct"
+        },
+        "__main__.main.Return": {
+            "cairo_type": "()",
+            "type": "type_definition"
+        },
+        "__main__.main.SIZEOF_LOCALS": {
+            "type": "const",
+            "value": 0
+        },
+        "__main__.main.a": {
+            "cairo_type": "felt",
+            "full_name": "__main__.main.a",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "pc": 0,
+                    "value": "cast(1, felt)"
+                }
+            ],
+            "type": "reference"
+        },
+        "__main__.main.b": {
+            "cairo_type": "felt",
+            "full_name": "__main__.main.b",
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "pc": 0,
+                    "value": "cast(2, felt)"
+                }
+            ],
+            "type": "reference"
+        }
+    },
+    "main_scope": "__main__",
+    "prime": "0x800000000000011000000000000000000000000000000000000000000000001",
+    "reference_manager": {
+        "references": [
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 0
+                },
+                "pc": 0,
+                "value": "cast(1, felt)"
+            },
+            {
+                "ap_tracking_data": {
+                    "group": 0,
+                    "offset": 0
+                },
+                "pc": 0,
+                "value": "cast(2, felt)"
+            }
+        ]
+    }
+}

--- a/src/cairo_run.rs
+++ b/src/cairo_run.rs
@@ -125,4 +125,17 @@ mod test {
         )
         .expect("Couldn't run program");
     }
+
+    #[test]
+    fn cairo_run_hint_print_vars() {
+        cairo_run::cairo_run_py(
+            "cairo_programs/hint_print_vars.json",
+            "main",
+            false,
+            false,
+            None,
+            None,
+        )
+        .expect("Couldn't run program");
+    }
 }

--- a/src/cairo_run.rs
+++ b/src/cairo_run.rs
@@ -66,13 +66,8 @@ pub fn cairo_run_py<'a>(
 
     if let Some(memory_path) = memory_file {
         let memory_path = PathBuf::from(memory_path);
-        match cairo_rs::cairo_run::write_binary_memory(&cairo_runner.relocated_memory, &memory_path)
-        {
-            Ok(()) => (),
-            Err(_e) => {
-                return Err(CairoRunError::Runner(RunnerError::WriteFail)).map_err(to_py_error)
-            }
-        }
+        cairo_rs::cairo_run::write_binary_memory(&cairo_runner.relocated_memory, &memory_path)
+            .map_err(|_| to_py_error(CairoRunError::Runner(RunnerError::WriteFail)))?;
     }
 
     Ok(())

--- a/src/cairo_run.rs
+++ b/src/cairo_run.rs
@@ -10,7 +10,6 @@ pub fn cairo_run_py<'a>(
     entrypoint: &'a str,
     trace_enabled: bool,
     print_output: bool,
-    // hint_processor: &'a dyn HintProcessor,
 ) -> PyResult<()> {
     let path = Path::new(path);
     let program = Program::new(path, entrypoint).map_err(to_py_error)?;
@@ -19,7 +18,6 @@ pub fn cairo_run_py<'a>(
     let vm = PyVM::new(program.prime, trace_enabled);
     let end = cairo_runner.initialize(&mut vm.vm.borrow_mut()).map_err(to_py_error)?;
 
-    // this has to change!
     run_until_pc(&mut cairo_runner, end, &vm).map_err(to_py_error)?;
 
     vm.vm.borrow_mut().verify_auto_deductions().map_err(to_py_error)?;
@@ -45,4 +43,20 @@ fn run_until_pc(cairo_runner: &mut CairoRunner, address: Relocatable, vm: &PyVM)
         )?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use crate::cairo_run;
+
+    #[test]
+    fn cairo_run_test() {
+        cairo_run::cairo_run_py(
+            "cairo_programs/fibonacci.json",
+            "main",
+            false,
+            false,
+        )
+        .expect("Couldn't run program");
+    }
 }

--- a/src/cairo_run.rs
+++ b/src/cairo_run.rs
@@ -66,7 +66,7 @@ mod test {
     use crate::cairo_run;
 
     #[test]
-    fn cairo_run_test() {
+    fn cairo_run_fibonacci() {
         cairo_run::cairo_run_py("cairo_programs/fibonacci.json", "main", false, false)
             .expect("Couldn't run program");
     }

--- a/src/cairo_run.rs
+++ b/src/cairo_run.rs
@@ -51,7 +51,6 @@ fn run_until_pc(
     let references = cairo_runner.get_reference_list();
     let hint_data_dictionary = cairo_runner.get_hint_data_dictionary(&references)?;
 
-    
     while vm.vm.borrow().run_context.pc != address {
         vm.step(
             cairo_runner.hint_executor,
@@ -74,12 +73,7 @@ mod test {
 
     #[test]
     fn cairo_run_array_sum() {
-        cairo_run::cairo_run_py(
-            "cairo_programs/array_sum.json",
-            "main",
-            false,
-            false,
-        )
-        .expect("Couldn't run program");
+        cairo_run::cairo_run_py("cairo_programs/array_sum.json", "main", false, false)
+            .expect("Couldn't run program");
     }
 }

--- a/src/cairo_run.rs
+++ b/src/cairo_run.rs
@@ -86,7 +86,7 @@ fn run_until_pc(
     let references = cairo_runner.get_reference_list();
     let hint_data_dictionary = cairo_runner.get_hint_data_dictionary(&references)?;
 
-    while vm.vm.borrow().run_context.pc != address {
+    while vm.vm.borrow().get_pc() != &address {
         vm.step(
             cairo_runner.hint_executor,
             &mut cairo_runner.exec_scopes,

--- a/src/cairo_run.rs
+++ b/src/cairo_run.rs
@@ -51,6 +51,7 @@ fn run_until_pc(
     let references = cairo_runner.get_reference_list();
     let hint_data_dictionary = cairo_runner.get_hint_data_dictionary(&references)?;
 
+    
     while vm.vm.borrow().run_context.pc != address {
         vm.step(
             cairo_runner.hint_executor,
@@ -69,5 +70,16 @@ mod test {
     fn cairo_run_fibonacci() {
         cairo_run::cairo_run_py("cairo_programs/fibonacci.json", "main", false, false)
             .expect("Couldn't run program");
+    }
+
+    #[test]
+    fn cairo_run_array_sum() {
+        cairo_run::cairo_run_py(
+            "cairo_programs/array_sum.json",
+            "main",
+            false,
+            false,
+        )
+        .expect("Couldn't run program");
     }
 }

--- a/src/cairo_run.rs
+++ b/src/cairo_run.rs
@@ -1,0 +1,48 @@
+use std::path::Path;
+use cairo_rs::{hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor, types::{program::Program, relocatable::Relocatable}, vm::{runners::cairo_runner::CairoRunner, errors::vm_errors::VirtualMachineError}, cairo_run::write_output};
+use pyo3::{pyfunction, PyResult};
+use crate::{utils::to_py_error, vm_core::PyVM};
+
+#[pyfunction]
+#[pyo3(name = "cairo_run")]
+pub fn cairo_run_py<'a>(
+    path: &'a str,
+    entrypoint: &'a str,
+    trace_enabled: bool,
+    print_output: bool,
+    // hint_processor: &'a dyn HintProcessor,
+) -> PyResult<()> {
+    let path = Path::new(path);
+    let program = Program::new(path, entrypoint).map_err(to_py_error)?;
+    let hint_processor = BuiltinHintProcessor::new_empty();
+    let mut cairo_runner = CairoRunner::new(&program, &hint_processor).map_err(to_py_error)?;
+    let vm = PyVM::new(program.prime, trace_enabled);
+    let end = cairo_runner.initialize(&mut vm.vm.borrow_mut()).map_err(to_py_error)?;
+
+    // this has to change!
+    run_until_pc(&mut cairo_runner, end, &vm).map_err(to_py_error)?;
+
+    vm.vm.borrow_mut().verify_auto_deductions().map_err(to_py_error)?;
+
+    cairo_runner.relocate(&mut vm.vm.borrow_mut()).map_err(to_py_error)?;
+
+    if print_output {
+        write_output(&mut cairo_runner, &mut vm.vm.borrow_mut()).map_err(to_py_error)?;
+    }
+
+    Ok(())
+}
+
+fn run_until_pc(cairo_runner: &mut CairoRunner, address: Relocatable, vm: &PyVM) -> Result<(), VirtualMachineError> {
+    let references = cairo_runner.get_reference_list();
+    let hint_data_dictionary = cairo_runner.get_hint_data_dictionary(&references)?;
+
+    while vm.vm.borrow().run_context.pc != address {
+        vm.step(
+            cairo_runner.hint_executor,
+            &mut cairo_runner.exec_scopes,
+            &hint_data_dictionary,
+        )?;
+    }
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,9 +9,11 @@ mod vm_core;
 
 use pyo3::prelude::*;
 use vm_core::PyVM;
+use cairo_run::cairo_run_py;
 
 #[pymodule]
 fn cairo_rs_py(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<PyVM>()?;
+    m.add_function(wrap_pyfunction!(cairo_run_py, m)?)?;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 mod ids;
+pub mod cairo_run;
 mod memory;
 mod memory_segments;
 mod relocatable;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
-mod ids;
 pub mod cairo_run;
+pub mod ids;
 mod memory;
 mod memory_segments;
 mod relocatable;
@@ -7,9 +7,9 @@ mod scope_manager;
 mod utils;
 mod vm_core;
 
+use cairo_run::cairo_run_py;
 use pyo3::prelude::*;
 use vm_core::PyVM;
-use cairo_run::cairo_run_py;
 
 #[pymodule]
 fn cairo_rs_py(_py: Python, m: &PyModule) -> PyResult<()> {

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -32,8 +32,7 @@ impl PyMemory {
         match self
             .vm
             .borrow()
-            .memory
-            .get(key)
+            .get_maybe(key)
             .map_err(|_| PyTypeError::new_err(MEMORY_GET_ERROR_MSG))?
         {
             Some(maybe_reloc) => Ok(Some(PyMaybeRelocatable::from(maybe_reloc).to_object(py))),
@@ -48,7 +47,6 @@ impl PyMemory {
 
         self.vm
             .borrow_mut()
-            .memory
             .insert_value(&key, value)
             .map_err(|_| PyValueError::new_err(MEMORY_SET_ERROR_MSG))
     }

--- a/src/vm_core.rs
+++ b/src/vm_core.rs
@@ -233,10 +233,9 @@ mod test {
         ]);
         vm.vm
             .borrow_mut()
-            .memory
-            .insert(
+            .insert_value(
                 &Relocatable::from((1, 1)),
-                &MaybeRelocatable::from(bigint!(2)),
+                &MaybeRelocatable::from(bigint!(2usize)),
             )
             .unwrap();
         let code = "ids.a = ids.b";
@@ -249,7 +248,7 @@ mod test {
             Ok(())
         );
         assert_eq!(
-            vm.vm.borrow().memory.get(&Relocatable::from((1, 2))),
+            vm.vm.borrow().get_maybe(&Relocatable::from((1, 2))),
             Ok(Some(&MaybeRelocatable::from(bigint!(2))))
         );
     }

--- a/src/vm_core.rs
+++ b/src/vm_core.rs
@@ -5,11 +5,13 @@ use crate::{
     memory::PyMemory, memory_segments::PySegmentManager, relocatable::PyRelocatable,
     utils::to_vm_error,
 };
+use cairo_rs::any_box;
 use cairo_rs::hint_processor::hint_processor_definition::HintProcessor;
-use cairo_rs::hint_processor::proxies::exec_scopes_proxy::{ExecutionScopesProxy, get_exec_scopes_proxy};
+use cairo_rs::hint_processor::proxies::exec_scopes_proxy::{
+    get_exec_scopes_proxy, ExecutionScopesProxy,
+};
 use cairo_rs::hint_processor::proxies::vm_proxy::get_vm_proxy;
 use cairo_rs::types::exec_scope::ExecutionScopes;
-use cairo_rs::any_box;
 use cairo_rs::vm::vm_core::VirtualMachine;
 use cairo_rs::{
     hint_processor::builtin_hint_processor::builtin_hint_processor_definition::HintProcessorData,
@@ -114,14 +116,14 @@ impl PyVM {
                     // if the hint is unknown to the builtin hint processor, use the execute_hint method from PyVM.
                     Err(VirtualMachineError::UnknownHint(_)) => {
                         let hint_data = hint_data
-                        .downcast_ref::<HintProcessorData>()
-                        .ok_or(VirtualMachineError::WrongHintData)?;
+                            .downcast_ref::<HintProcessorData>()
+                            .ok_or(VirtualMachineError::WrongHintData)?;
 
-                    self.execute_hint(hint_data, &mut exec_scopes_proxy)?;
-                    },
+                        self.execute_hint(hint_data, &mut exec_scopes_proxy)?;
+                    }
                     // if there is any other error, return that error
                     Err(e) => return Err(e),
-                    Ok(_) => {},
+                    Ok(_) => {}
                 }
             }
         }

--- a/src/vm_core.rs
+++ b/src/vm_core.rs
@@ -104,7 +104,6 @@ impl PyVM {
         exec_scopes: &mut ExecutionScopes,
         hint_data_dictionary: &HashMap<usize, Vec<Box<dyn Any>>>,
     ) -> Result<(), VirtualMachineError> {
-
         let pc_offset = self.vm.borrow().run_context.pc.offset;
 
         if let Some(hint_list) = hint_data_dictionary.get(&pc_offset) {

--- a/src/vm_core.rs
+++ b/src/vm_core.rs
@@ -103,7 +103,7 @@ impl PyVM {
         exec_scopes: &mut ExecutionScopes,
         hint_data_dictionary: &HashMap<usize, Vec<Box<dyn Any>>>,
     ) -> Result<(), VirtualMachineError> {
-        let pc_offset = self.vm.borrow().run_context.pc.offset;
+        let pc_offset = self.vm.borrow().get_pc().offset;
 
         if let Some(hint_list) = hint_data_dictionary.get(&pc_offset) {
             for hint_data in hint_list.iter() {
@@ -275,9 +275,9 @@ mod test {
 
         let hint_processor = BuiltinHintProcessor::new_empty();
 
-        vm.vm.borrow_mut().run_context.pc = Relocatable::from((0, 0));
-        vm.vm.borrow_mut().run_context.ap = 2usize;
-        vm.vm.borrow_mut().run_context.fp = 2usize;
+        vm.vm.borrow_mut().set_pc(Relocatable::from((0, 0)));
+        vm.vm.borrow_mut().set_ap(2);
+        vm.vm.borrow_mut().set_fp(2);
 
         vm.vm
             .borrow_mut()
@@ -315,9 +315,9 @@ mod test {
 
         let hint_processor = BuiltinHintProcessor::new_empty();
 
-        vm.vm.borrow_mut().run_context.pc = Relocatable::from((0, 0));
-        vm.vm.borrow_mut().run_context.ap = 2usize;
-        vm.vm.borrow_mut().run_context.fp = 2usize;
+        vm.vm.borrow_mut().set_pc(Relocatable::from((0, 0)));
+        vm.vm.borrow_mut().set_ap(2);
+        vm.vm.borrow_mut().set_fp(2);
 
         vm.vm
             .borrow_mut()

--- a/src/vm_core.rs
+++ b/src/vm_core.rs
@@ -10,7 +10,6 @@ use cairo_rs::hint_processor::hint_processor_definition::HintProcessor;
 use cairo_rs::hint_processor::proxies::exec_scopes_proxy::{
     get_exec_scopes_proxy, ExecutionScopesProxy,
 };
-use cairo_rs::hint_processor::proxies::vm_proxy::get_vm_proxy;
 use cairo_rs::types::exec_scope::ExecutionScopes;
 use cairo_rs::vm::vm_core::VirtualMachine;
 use cairo_rs::{
@@ -108,13 +107,12 @@ impl PyVM {
 
         if let Some(hint_list) = hint_data_dictionary.get(&pc_offset) {
             let mut vm = self.vm.borrow_mut();
-            let mut vm_proxy = get_vm_proxy(&mut vm);
 
             for hint_data in hint_list.iter() {
                 //We create a new proxy with every hint as the current scope can change
                 let mut exec_scopes_proxy = get_exec_scopes_proxy(exec_scopes);
 
-                match hint_executor.execute_hint(&mut vm_proxy, &mut exec_scopes_proxy, hint_data) {
+                match hint_executor.execute_hint(&mut vm, &mut exec_scopes_proxy, hint_data) {
                     // if the hint is unknown to the builtin hint processor, use the execute_hint method from PyVM.
                     Err(VirtualMachineError::UnknownHint(_)) => {
                         let hint_data = hint_data

--- a/src/vm_core.rs
+++ b/src/vm_core.rs
@@ -104,7 +104,10 @@ impl PyVM {
         exec_scopes: &mut ExecutionScopes,
         hint_data_dictionary: &HashMap<usize, Vec<Box<dyn Any>>>,
     ) -> Result<(), VirtualMachineError> {
-        if let Some(hint_list) = hint_data_dictionary.get(&self.vm.borrow().run_context.pc.offset) {
+
+        let pc_offset = self.vm.borrow().run_context.pc.offset;
+
+        if let Some(hint_list) = hint_data_dictionary.get(&pc_offset) {
             let mut vm = self.vm.borrow_mut();
             let mut vm_proxy = get_vm_proxy(&mut vm);
 


### PR DESCRIPTION
This PR adds the implementation of cairo_run for this crate, namely `cairo_run_py`. 
It depends on the cairo-rs PR:
https://github.com/lambdaclass/cairo-rs/pull/475

The structure of the function is very similar to `cairo_run` from cairo-rs, with some little changes so that it fits properly into this scheme.

A function `run_until_pc` analogous to the CairoRunner's method from cairo-rs was implemented, that receives the CairoRunner as an argument.

NOTE: In contrast to `cairo_run`, `cairo_run_py` initializes the hint processor instead of receiving it as an argument. The implementation was much simpler this way, and for the moment I don't think a custom hint processor will be needed, but this could be changed in the future. Another difference is that the trace file and memory file are passed as arguments for `cairo_run_py`.
Some compiled json programs were added for testing, but they should be removed once the Makefile is configured correctly for tests