### PR TITLE
Add support for hint_locals

### DIFF
--- a/src/cairo_run.rs
+++ b/src/cairo_run.rs
@@ -36,7 +36,7 @@ pub fn cairo_run_py<'a>(
     let end = cairo_runner
         .initialize(&mut vm.vm.borrow_mut())
         .map_err(to_py_error)?;
-    let mut hint_locals = hint_locals.unwrap_or(HashMap::new());
+    let mut hint_locals = hint_locals.unwrap_or_default();
     run_until_pc(&mut cairo_runner, end, &vm, &mut hint_locals).map_err(to_py_error)?;
 
     vm.vm

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -32,7 +32,7 @@ impl PyIds {
         let hint_ref = self
             .references
             .get(name)
-            .ok_or(to_py_error(IDS_GET_ERROR_MSG))?;
+            .ok_or_else(|| to_py_error(IDS_GET_ERROR_MSG))?;
         Ok(get_value_from_reference(&self.vm.borrow(), hint_ref, &self.ap_tracking)?.to_object(py))
     }
 
@@ -40,7 +40,7 @@ impl PyIds {
         let hint_ref = self
             .references
             .get(name)
-            .ok_or(to_py_error(IDS_SET_ERROR_MSG))?;
+            .ok_or_else(|| to_py_error(IDS_SET_ERROR_MSG))?;
         let var_addr = compute_addr_from_reference(hint_ref, &self.vm.borrow(), &self.ap_tracking)?;
         self.vm
             .borrow_mut()
@@ -77,7 +77,7 @@ pub fn get_value_from_reference(
         return Ok(PyMaybeRelocatable::from(num));
     }
     //Then calculate address
-    let var_addr = compute_addr_from_reference(hint_reference, &vm, ap_tracking)?;
+    let var_addr = compute_addr_from_reference(hint_reference, vm, ap_tracking)?;
     let value = if hint_reference.dereference {
         vm.get_maybe(&var_addr).map_err(to_py_error)?
     } else {
@@ -123,7 +123,7 @@ pub fn compute_addr_from_reference(
         None => return Err(to_py_error(VirtualMachineError::NoRegisterInReference)),
     };
     if hint_reference.offset1.is_negative()
-        && base_addr.offset < hint_reference.offset1.abs() as usize
+        && base_addr.offset < hint_reference.offset1.unsigned_abs() as usize
     {
         return Err(to_py_error(VirtualMachineError::FailedToGetIds));
     }

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -123,7 +123,7 @@ pub fn compute_addr_from_reference(
         None => return Err(to_py_error(VirtualMachineError::NoRegisterInReference)),
     };
     if hint_reference.offset1.is_negative()
-        && base_addr.offset < hint_reference.offset1.unsigned_abs() as usize
+        && base_addr.offset < hint_reference.offset1.unsigned_abs().try_into()?
     {
         return Err(to_py_error(VirtualMachineError::FailedToGetIds));
     }

--- a/src/relocatable.rs
+++ b/src/relocatable.rs
@@ -15,7 +15,7 @@ pub enum PyMaybeRelocatable {
 }
 
 #[pyclass(name = "Relocatable")]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PyRelocatable {
     index: usize,
     offset: usize,
@@ -41,11 +41,11 @@ impl PyRelocatable {
     pub fn __sub__(&self, value: PyMaybeRelocatable, py: Python) -> PyResult<PyObject> {
         match value {
             PyMaybeRelocatable::Int(value) => {
-                return Ok(PyMaybeRelocatable::RelocatableValue(PyRelocatable {
+                Ok(PyMaybeRelocatable::RelocatableValue(PyRelocatable {
                     index: self.index,
                     offset: self.offset - bigint_to_usize(&value).unwrap(),
                 })
-                .to_object(py));
+                .to_object(py))
             }
             PyMaybeRelocatable::RelocatableValue(address) => {
                 if self.index == address.index && self.offset >= address.offset {
@@ -65,7 +65,7 @@ impl PyRelocatable {
                 if self.index == other.index {
                     Ok(self.offset < other.offset)
                 } else {
-                    return Err(PyArithmeticError::new_err(PYRELOCATABLE_COMPARE_ERROR));
+                    Err(PyArithmeticError::new_err(PYRELOCATABLE_COMPARE_ERROR))
                 }
             }
             CompareOp::Le => {
@@ -81,14 +81,14 @@ impl PyRelocatable {
                 if self.index == other.index {
                     Ok(self.offset > other.offset)
                 } else {
-                    return Err(PyArithmeticError::new_err(PYRELOCATABLE_COMPARE_ERROR));
+                    Err(PyArithmeticError::new_err(PYRELOCATABLE_COMPARE_ERROR))
                 }
             }
             CompareOp::Ge => {
                 if self.index == other.index {
                     Ok(self.offset >= other.offset)
                 } else {
-                    return Err(PyArithmeticError::new_err(PYRELOCATABLE_COMPARE_ERROR));
+                    Err(PyArithmeticError::new_err(PYRELOCATABLE_COMPARE_ERROR))
                 }
             }
         }
@@ -105,7 +105,7 @@ impl From<PyMaybeRelocatable> for MaybeRelocatable {
             PyMaybeRelocatable::RelocatableValue(rel) => {
                 MaybeRelocatable::RelocatableValue(Relocatable::from((rel.index, rel.offset)))
             }
-            PyMaybeRelocatable::Int(num) => MaybeRelocatable::Int(BigInt::from(num)),
+            PyMaybeRelocatable::Int(num) => MaybeRelocatable::Int(num),
         }
     }
 }

--- a/src/scope_manager.rs
+++ b/src/scope_manager.rs
@@ -34,6 +34,12 @@ impl PyEnterScope {
     }
 }
 
+impl Default for PyEnterScope {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[pymethods]
 impl PyEnterScope {
     pub fn __call__(&mut self, variables: Option<HashMap<String, PyObject>>) {
@@ -63,6 +69,12 @@ impl PyExitScope {
             scopes.exit_scope()?
         }
         Ok(())
+    }
+}
+
+impl Default for PyExitScope {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/vm_core.rs
+++ b/src/vm_core.rs
@@ -80,7 +80,6 @@ impl PyVM {
             for (name, pyobj) in hint_locals.iter() {
                 locals.set_item(name, pyobj).map_err(to_vm_error)?;
             }
-            println!("Code: {:?}", hint_data.code);
             py.run(&hint_data.code, Some(globals), Some(locals))
                 .map_err(to_vm_error)?;
 
@@ -166,7 +165,6 @@ pub(crate) fn update_scope_hint_locals(
     for (name, elem) in locals {
         let name = name.to_string();
         if names.contains(&name) {
-            println!("REV WORD: {:?}", elem.to_object(py).to_string());
             hint_locals.insert(name, elem.to_object(py));
         } else {
             exec_scopes.assign_or_update_variable(&name, any_box!(elem.to_object(py)));
@@ -429,19 +427,9 @@ mod test {
         );
         let code = "word = word[::-1]
 print(word)";
-        let code2 = "print(word)";
         let hint_data = HintProcessorData::new_default(code.to_string(), HashMap::new());
         let word = Python::with_gil(|py| -> PyObject { "fruity".to_string().to_object(py) });
         let mut hint_locals = HashMap::from([("word".to_string(), word)]);
-        assert_eq!(
-            vm.execute_hint(
-                &hint_data,
-                &mut hint_locals,
-                &mut get_exec_scopes_proxy(&mut ExecutionScopes::new())
-            ),
-            Ok(())
-        );
-        let hint_data = HintProcessorData::new_default(code2.to_string(), HashMap::new());
         assert_eq!(
             vm.execute_hint(
                 &hint_data,


### PR DESCRIPTION
Add support for hint_locals
hint_locals is a dictionary of python objects that can be accessed and modified by any hint regardless of scopes