### PR TITLE
Fix PyRelocatable index and remove ExecScopesProxy

### DIFF
--- a/src/relocatable.rs
+++ b/src/relocatable.rs
@@ -17,14 +17,14 @@ pub enum PyMaybeRelocatable {
 #[pyclass(name = "Relocatable")]
 #[derive(Clone, Debug, PartialEq)]
 pub struct PyRelocatable {
-    index: usize,
+    index: isize,
     offset: usize,
 }
 
 #[pymethods]
 impl PyRelocatable {
     #[new]
-    pub fn new(tuple: (usize, usize)) -> PyRelocatable {
+    pub fn new(tuple: (isize, usize)) -> PyRelocatable {
         PyRelocatable {
             index: tuple.0,
             offset: tuple.1,
@@ -179,8 +179,8 @@ impl From<&PyRelocatable> for Relocatable {
     }
 }
 
-impl From<(usize, usize)> for PyRelocatable {
-    fn from(val: (usize, usize)) -> Self {
+impl From<(isize, usize)> for PyRelocatable {
+    fn from(val: (isize, usize)) -> Self {
         PyRelocatable::new((val.0, val.1))
     }
 }

--- a/src/scope_manager.rs
+++ b/src/scope_manager.rs
@@ -1,8 +1,7 @@
 use std::{any::Any, collections::HashMap};
 
 use cairo_rs::{
-    any_box, hint_processor::proxies::exec_scopes_proxy::ExecutionScopesProxy,
-    vm::errors::vm_errors::VirtualMachineError,
+    any_box, types::exec_scope::ExecutionScopes, vm::errors::vm_errors::VirtualMachineError,
 };
 use pyo3::{pyclass, pymethods, PyObject};
 
@@ -19,10 +18,7 @@ impl PyEnterScope {
         }
     }
 
-    pub fn update_scopes(
-        &self,
-        scopes: &mut ExecutionScopesProxy,
-    ) -> Result<(), VirtualMachineError> {
+    pub fn update_scopes(&self, scopes: &mut ExecutionScopes) -> Result<(), VirtualMachineError> {
         for scope_variables in self.new_scopes.iter() {
             let mut new_scope = HashMap::<String, Box<dyn Any>>::new();
             for (name, pyobj) in scope_variables {
@@ -55,10 +51,7 @@ impl PyExitScope {
         PyExitScope { num: 0 }
     }
 
-    pub fn update_scopes(
-        &self,
-        scopes: &mut ExecutionScopesProxy,
-    ) -> Result<(), VirtualMachineError> {
+    pub fn update_scopes(&self, scopes: &mut ExecutionScopes) -> Result<(), VirtualMachineError> {
         for _ in 0..self.num {
             scopes.exit_scope()?
         }

--- a/src/vm_core.rs
+++ b/src/vm_core.rs
@@ -368,9 +368,15 @@ mod test {
         let code_b = "assert(num == 6)";
         let hint_data = HintProcessorData::new_default(code_a.to_string(), HashMap::new());
 
-        assert_eq!(vm.execute_hint(&hint_data, &mut HashMap::new(), &mut exec_scopes), Ok(()));
+        assert_eq!(
+            vm.execute_hint(&hint_data, &mut HashMap::new(), &mut exec_scopes),
+            Ok(())
+        );
         let hint_data = HintProcessorData::new_default(code_b.to_string(), HashMap::new());
-        assert_eq!(vm.execute_hint(&hint_data, &mut HashMap::new(), &mut exec_scopes), Ok(()));
+        assert_eq!(
+            vm.execute_hint(&hint_data, &mut HashMap::new(), &mut exec_scopes),
+            Ok(())
+        );
     }
 
     #[test]
@@ -422,11 +428,7 @@ print(word)";
         let word = Python::with_gil(|py| -> PyObject { "fruity".to_string().to_object(py) });
         let mut hint_locals = HashMap::from([("word".to_string(), word)]);
         assert_eq!(
-            vm.execute_hint(
-                &hint_data,
-                &mut hint_locals,
-                &mut ExecutionScopes::new()
-            ),
+            vm.execute_hint(&hint_data, &mut hint_locals, &mut ExecutionScopes::new()),
             Ok(())
         );
         let word_res = Python::with_gil(|py| -> String {
@@ -465,7 +467,10 @@ print(word)";
         let mut exec_scopes = ExecutionScopes::new();
         let code = "vm_enter_scope()";
         let hint_data = HintProcessorData::new_default(code.to_string(), HashMap::new());
-        assert_eq!(vm.execute_hint(&hint_data, &mut HashMap::new(), &mut exec_scopes), Ok(()));
+        assert_eq!(
+            vm.execute_hint(&hint_data, &mut HashMap::new(), &mut exec_scopes),
+            Ok(())
+        );
         assert_eq!(exec_scopes.data.len(), 2)
     }
 
@@ -479,7 +484,10 @@ print(word)";
         let code = "vm_enter_scope()
 vm_exit_scope()";
         let hint_data = HintProcessorData::new_default(code.to_string(), HashMap::new());
-        assert_eq!(vm.execute_hint(&hint_data, &mut HashMap::new(), &mut exec_scopes), Ok(()));
+        assert_eq!(
+            vm.execute_hint(&hint_data, &mut HashMap::new(), &mut exec_scopes),
+            Ok(())
+        );
         assert_eq!(exec_scopes.data.len(), 1)
     }
 
@@ -493,9 +501,15 @@ vm_exit_scope()";
         let code_a = "vm_enter_scope({'n': 12})";
         let code_b = "assert(n == 12)";
         let hint_data = HintProcessorData::new_default(code_a.to_string(), HashMap::new());
-        assert_eq!(vm.execute_hint(&hint_data, &mut HashMap::new(), &mut exec_scopes), Ok(()));
+        assert_eq!(
+            vm.execute_hint(&hint_data, &mut HashMap::new(), &mut exec_scopes),
+            Ok(())
+        );
         let hint_data = HintProcessorData::new_default(code_b.to_string(), HashMap::new());
-        assert_eq!(vm.execute_hint(&hint_data, &mut HashMap::new(), &mut exec_scopes), Ok(()));
+        assert_eq!(
+            vm.execute_hint(&hint_data, &mut HashMap::new(), &mut exec_scopes),
+            Ok(())
+        );
         assert_eq!(exec_scopes.data.len(), 2);
         assert!(exec_scopes.data[0].is_empty());
     }


### PR DESCRIPTION
Solves #27.
This PR fixes the crate to be compatible with the changes made to `cairo-rs`:
* `PyRelocatable` has a segment index of type `isize`, analogous to the `Relocatable` struct of `cairo-rs`.
* `ExecScopesProxy` has been replaced to `ExecScopes`