### PR TITLE
Import Python builtins in execute_hint function

### DIFF
--- a/src/vm_core.rs
+++ b/src/vm_core.rs
@@ -58,7 +58,13 @@ impl PyVM {
 
             let locals = get_scope_locals(exec_scopes, py)?;
 
-            let globals = PyDict::new(py);
+            // This line imports Python builtins. If not imported, this will run only with Python 3.10
+            let globals = py
+                .import("__main__")
+                .map_err(to_vm_error)?
+                .dict()
+                .copy()
+                .map_err(to_vm_error)?;
 
             globals
                 .set_item("memory", pycell!(py, memory))


### PR DESCRIPTION
This PR adds Python builtins import so that the module `cairo_rs_py` can run with any Python version.
Without this, Python 3.10+ are the only ones that can use the module correctly.