### PR TITLE
Point cairo-rs to rev a272cd

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,6 @@ default = ["pyo3/num-bigint", "pyo3/auto-initialize"]
 
 [dependencies]
 pyo3 = { version = "0.16.5" }
-cairo-rs = { git = "https://github.com/lambdaclass/cairo-rs.git"}
+cairo-rs = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "a272cd2800eef209fef6caa02cb9a0efd1d70e50" }
 num-bigint = "0.4"
 lazy_static = "1.4.0"


### PR DESCRIPTION
This fixes the cairo-rs version used to a272cd to allow decoupling changes between the projects and avoid stuff breaking behind cairo-rs-py's back.