### PR TITLE
Move execution scope and hint_local variables to globals

### DIFF
--- a/src/vm_core.rs
+++ b/src/vm_core.rs
@@ -614,7 +614,7 @@ vm_exit_scope()";
     }
 
     #[test]
-    fn list_bug() {
+    fn list_comprehension() {
         let vm = PyVM::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             false,

--- a/src/vm_core.rs
+++ b/src/vm_core.rs
@@ -47,7 +47,7 @@ const GLOBAL_NAMES: [&str; 16] = [
     "__builtins__",
     "__spec__",
     "__loader__",
-    "__name__"
+    "__name__",
 ];
 
 #[pyclass(unsendable)]
@@ -148,14 +148,14 @@ impl PyVM {
             let prime = self.vm.borrow().get_prime().clone();
 
             // This line imports Python builtins. If not imported, this will run only with Python 3.10
-            let mut globals = py
+            let globals = py
                 .import("__main__")
                 .map_err(to_vm_error)?
                 .dict()
                 .copy()
                 .map_err(to_vm_error)?;
 
-            add_scope_locals(&mut globals, exec_scopes)?;
+            add_scope_locals(globals, exec_scopes)?;
 
             globals
                 .set_item("memory", pycell!(py, memory))
@@ -275,7 +275,7 @@ impl PyVM {
     }
 }
 
-pub(crate) fn add_scope_locals<'a>(
+pub(crate) fn add_scope_locals(
     globals: &PyDict,
     exec_scopes: &ExecutionScopes,
 ) -> Result<(), VirtualMachineError> {
@@ -295,7 +295,7 @@ pub(crate) fn update_scope_hint_locals(
 ) {
     for (name, elem) in globals {
         let name = name.to_string();
-        if !GLOBAL_NAMES.contains(&&name.as_str()) {
+        if !GLOBAL_NAMES.contains(&name.as_str()) {
             if hint_locals.keys().cloned().any(|x| x == name) {
                 hint_locals.insert(name, elem.to_object(py));
             } else {

--- a/src/vm_core.rs
+++ b/src/vm_core.rs
@@ -188,7 +188,6 @@ impl PyVM {
             for (name, pyobj) in hint_locals.iter() {
                 globals.set_item(name, pyobj).map_err(to_vm_error)?;
             }
-            println!("Running a hint: {:?}", hint_data.code);
             py.run(&hint_data.code, Some(globals), None)
                 .map_err(to_vm_error)?;
 
@@ -615,7 +614,6 @@ vm_exit_scope()";
     }
 
     #[test]
-    //FAILING
     fn list_bug() {
         let vm = PyVM::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),


### PR DESCRIPTION
Motivation: A bug was found when using list comprehension inside hints. When a local dictionary is used, variables created inside the hint are stored in locals, but list comprehension looks for variables in locals, leading to undefined name errors. In order to fix this, the local dictionary was removed so that every variable would be stored and fetched from globals
- Move executions scope and hint_local variables to global dictionary
- Remove local dictionary
- Add test for hint using list comprehension