### PR TITLE
Add setattr and fix getattr to PyTypeId struct

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ default = ["pyo3/num-bigint", "pyo3/auto-initialize"]
 
 [dependencies]
 pyo3 = { version = "0.16.5" }
-cairo-rs = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "86d83205fd3c32bd53e7a29eeabff9ae67769a5f" }
+cairo-rs = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "b99f77f65156394b7e4a7c1dd52839e28f45ccbf" }
 num-bigint = "0.4"
 lazy_static = "1.4.0"
 

--- a/hints_tests.py
+++ b/hints_tests.py
@@ -15,7 +15,7 @@ if __name__ == "__main__":
     test_program("ec_mul_inner")
     # test_program("ec_negate") # ValueError: Variable value not present in current execution scope
     test_program("assert_nn_hint")
-    # test_program("pow") # Custom Hint Error: AttributeError: 'builtins.Relocatable' object has no attribute 'exp'
+    test_program("pow") # Custom Hint Error: AttributeError: 'builtins.Relocatable' object has no attribute 'exp'
     test_program("is_nn")
     test_program("is_positive")
     test_program("assert_not_zero")

--- a/hints_tests.py
+++ b/hints_tests.py
@@ -15,7 +15,7 @@ if __name__ == "__main__":
     test_program("ec_mul_inner")
     # test_program("ec_negate") # ValueError: Variable value not present in current execution scope
     test_program("assert_nn_hint")
-    test_program("pow") # Custom Hint Error: AttributeError: 'builtins.Relocatable' object has no attribute 'exp'
+    test_program("pow")
     test_program("is_nn")
     test_program("is_positive")
     test_program("assert_not_zero")
@@ -41,8 +41,8 @@ if __name__ == "__main__":
     test_program("split_int")
     test_program("split_64")
     test_program("uint256_add")
-    test_program("uint256_sqrt") # Custom Hint Error: ValueError: Failed to get ids value
-    test_program("uint256_unsigned_div_rem") # Custom Hint Error: AttributeError: 'builtins.PyTypedId' object has no attribute 'low'
+    test_program("uint256_sqrt")
+    test_program("uint256_unsigned_div_rem")
     test_program("uint256_signed_nn")
     test_program("bigint_to_uint256")
     test_program("usort")

--- a/hints_tests.py
+++ b/hints_tests.py
@@ -26,8 +26,8 @@ if __name__ == "__main__":
     # test_program("is_zero") # Custom Hint Error: NameError: name 'to_felt_or_relocatable' is not defined
     test_program("div_mod_n")
     test_program("get_point_from_x")
-    # test_program("compute_slope") # ValueError: verify_zero: Invalid input 115792089237316195422966786669080118156105500425196604465460999109169899370287
-    # test_program("ec_doble") # ValueError: verify_zero: Invalid input -16289419471130179420082969341938614127691693058652915375562000746308067257337178941098315954201487874090
+    test_program("compute_slope") # ValueError: verify_zero: Invalid input 115792089237316195422966786669080118156105500425196604465460999109169899370287
+    test_program("ec_doble") # ValueError: verify_zero: Invalid input -16289419471130179420082969341938614127691693058652915375562000746308067257337178941098315954201487874090
     test_program("memcpy")
     test_program("memset")
     test_program("dict_new")
@@ -51,6 +51,5 @@ if __name__ == "__main__":
     test_program("signed_div_rem")
     test_program("find_element")
     test_program("search_sorted_lower")
-    test_program("struct_struct")
     # test_program("set_add") # Custom Hint Error: AttributeError: 'builtins.PyMemory' object has no attribute 'get_range'
     print("\nAll test have passed")

--- a/hints_tests.py
+++ b/hints_tests.py
@@ -26,8 +26,8 @@ if __name__ == "__main__":
     # test_program("is_zero") # Custom Hint Error: NameError: name 'to_felt_or_relocatable' is not defined
     test_program("div_mod_n")
     test_program("get_point_from_x")
-    test_program("compute_slope") # ValueError: verify_zero: Invalid input 115792089237316195422966786669080118156105500425196604465460999109169899370287
-    test_program("ec_doble") # ValueError: verify_zero: Invalid input -16289419471130179420082969341938614127691693058652915375562000746308067257337178941098315954201487874090
+    test_program("compute_slope")
+    test_program("ec_doble")
     test_program("memcpy")
     test_program("memset")
     test_program("dict_new")

--- a/hints_tests.py
+++ b/hints_tests.py
@@ -41,8 +41,8 @@ if __name__ == "__main__":
     test_program("split_int")
     test_program("split_64")
     test_program("uint256_add")
-    # test_program("uint256_sqrt") # Custom Hint Error: ValueError: Failed to get ids value
-    # test_program("uint256_unsigned_div_rem") # Custom Hint Error: AttributeError: 'builtins.PyTypedId' object has no attribute 'low'
+    test_program("uint256_sqrt") # Custom Hint Error: ValueError: Failed to get ids value
+    test_program("uint256_unsigned_div_rem") # Custom Hint Error: AttributeError: 'builtins.PyTypedId' object has no attribute 'low'
     test_program("uint256_signed_nn")
     test_program("bigint_to_uint256")
     test_program("usort")
@@ -51,5 +51,6 @@ if __name__ == "__main__":
     test_program("signed_div_rem")
     test_program("find_element")
     test_program("search_sorted_lower")
+    test_program("struct_struct")
     # test_program("set_add") # Custom Hint Error: AttributeError: 'builtins.PyMemory' object has no attribute 'get_range'
     print("\nAll test have passed")

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -1,5 +1,6 @@
 use crate::utils::const_path_to_const_name;
 use num_bigint::BigInt;
+use pyo3::exceptions::PyValueError;
 use std::{cell::RefCell, collections::HashMap, rc::Rc};
 
 use cairo_rs::{
@@ -163,7 +164,7 @@ impl PyTypedId {
                 vm.insert_value(&field_addr, val).map_err(to_py_error)
             }
 
-            cairo_type => todo!(),
+            _cairo_type => return Err(PyValueError::new_err("Error: It should be possible to assign a struct into another struct's field. See issue #86")),
         }
     }
 }

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -129,7 +129,7 @@ impl PyTypedId {
 
                     cairo_type => PyTypedId {
                         vm: self.vm.clone(),
-                        hint_value: self.hint_value.clone(),
+                        hint_value: self.hint_value.add(member.offset).map_err(to_py_error)?,
                         cairo_type: cairo_type.to_string(),
                         struct_types: self.struct_types.clone(),
                     }

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -163,7 +163,7 @@ impl PyTypedId {
                 vm.insert_value(&field_addr, val).map_err(to_py_error)
             }
 
-            _ => unreachable!(),
+            cairo_type => todo!(),
         }
     }
 }

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -164,7 +164,7 @@ impl PyTypedId {
                 vm.insert_value(&field_addr, val).map_err(to_py_error)
             }
 
-            _cairo_type => return Err(PyValueError::new_err("Error: It should be possible to assign a struct into another struct's field. See issue #86")),
+            _cairo_type => Err(PyValueError::new_err("Error: It should be possible to assign a struct into another struct's field. See issue #86")),
         }
     }
 }

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -22,6 +22,7 @@ use crate::{relocatable::PyMaybeRelocatable, utils::to_py_error, vm_core::PyVM};
 
 const IDS_GET_ERROR_MSG: &str = "Failed to get ids value";
 const IDS_SET_ERROR_MSG: &str = "Failed to set ids value to Cairo memory";
+const STRUCT_TYPES_GET_ERROR_MSG: &str = "Failed to get struct type";
 
 #[pyclass(unsendable)]
 pub struct PyIds {
@@ -111,9 +112,11 @@ impl PyTypedId {
     #[getter]
     fn __getattr__(&self, py: Python, name: &str) -> PyResult<PyObject> {
         let struct_type = self.struct_types.get(&self.cairo_type).unwrap();
+
         if name == "address_" {
             return Ok(PyMaybeRelocatable::from(self.hint_value.clone()).to_object(py));
         }
+
         match struct_type.get(name) {
             Some(member) => {
                 let vm = self.vm.borrow();
@@ -123,6 +126,7 @@ impl PyTypedId {
                         .map_err(to_py_error)?
                         .map(|x| PyMaybeRelocatable::from(x).to_object(py))
                         .unwrap_or_else(|| py.None()),
+
                     cairo_type => PyTypedId {
                         vm: self.vm.clone(),
                         hint_value: self.hint_value.clone(),
@@ -136,6 +140,30 @@ impl PyTypedId {
                 "'PyTypeId' object has no attribute '{}'",
                 name
             ))),
+        }
+    }
+
+    pub fn __setattr__(&self, field_name: &str, val: PyMaybeRelocatable) -> PyResult<()> {
+        let struct_type = self
+            .struct_types
+            .get(&self.cairo_type)
+            .ok_or_else(|| to_py_error(STRUCT_TYPES_GET_ERROR_MSG))?;
+
+        let member = struct_type.get(field_name).ok_or_else(|| {
+            PyAttributeError::new_err(format!(
+                "'PyTypeId' object has no attribute '{}'",
+                field_name
+            ))
+        })?;
+
+        let mut vm = self.vm.borrow_mut();
+        match member.cairo_type.as_str() {
+            "felt" | "felt*" => {
+                let field_addr = self.hint_value.add(member.offset).map_err(to_py_error)?;
+                vm.insert_value(&field_addr, val).map_err(to_py_error)
+            }
+
+            _ => unreachable!(),
         }
     }
 }


### PR DESCRIPTION
This PR adds support for assigning PyTypeIds fields. This is useful when assigning struct fields inside a hint.
It also corrects the `__getattr__` method.

With this fixes, the following tests run:
* pow
* compute_slope
* ec_double
* uint256_unsigned_div_rem
* uint256_sqrt

**Note**: If a field inside a struct is another struct and we want to assign a struct there, it would fail. It is not clear at the moment if this should be supported. See issue #86. 