### PR TITLE
Expose get_segment_used_size in cairo runner

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ default = ["pyo3/num-bigint", "pyo3/auto-initialize"]
 
 [dependencies]
 pyo3 = { version = "0.16.5" }
-cairo-rs = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "ba2ff5c52ad3c3bab5dbeb942e3fb754b65c46cb" }
+cairo-rs = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "861557a5394dededb46431030b1d274bf7289603" }
 num-bigint = "0.4"
 lazy_static = "1.4.0"
 

--- a/src/cairo_runner.rs
+++ b/src/cairo_runner.rs
@@ -265,4 +265,46 @@ mod test {
         .unwrap();
         runner.write_output().unwrap();
     }
+
+    #[test]
+    fn get_segment_used_size_of_segment_0() {
+        let mut runner = PyCairoRunner::new(
+            "cairo_programs/fibonacci.json".to_string(),
+            "main".to_string(),
+            None,
+        )
+        .unwrap();
+        runner.cairo_run_py(false, None, None, None).unwrap();
+        Python::with_gil(|py| {
+            assert_eq!(
+                24,
+                runner
+                    .get_segment_used_size(0, py)
+                    .unwrap()
+                    .extract::<usize>(py)
+                    .unwrap()
+            )
+        });
+    }
+
+    #[test]
+    fn get_segment_used_size_of_segment_2() {
+        let mut runner = PyCairoRunner::new(
+            "cairo_programs/fibonacci.json".to_string(),
+            "main".to_string(),
+            None,
+        )
+        .unwrap();
+        runner.cairo_run_py(false, None, None, None).unwrap();
+        Python::with_gil(|py| {
+            assert_eq!(
+                0,
+                runner
+                    .get_segment_used_size(2, py)
+                    .unwrap()
+                    .extract::<usize>(py)
+                    .unwrap()
+            )
+        });
+    }
 }

--- a/src/cairo_runner.rs
+++ b/src/cairo_runner.rs
@@ -12,12 +12,14 @@ use cairo_rs::{
     },
 };
 use num_bigint::{BigInt, Sign};
-use pyo3::prelude::*;
+use pyo3::{exceptions::PyTypeError, prelude::*};
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
     rc::Rc,
 };
+
+const MEMORY_GET_SEGMENT_USED_SIZE_MSG: &str = "Failed to segment used size";
 
 #[pyclass(unsendable)]
 #[pyo3(name = "CairoRunner")]
@@ -172,6 +174,16 @@ impl PyCairoRunner {
             .get_execution_resources(&self.pyvm.vm.borrow())
             .map(PyExecutionResources)
             .map_err(to_py_error)
+    }
+
+    pub fn get_segment_used_size(&self, index: usize, py: Python) -> PyResult<PyObject> {
+        Ok(self
+            .pyvm
+            .vm
+            .borrow()
+            .get_segment_used_size(index)
+            .ok_or_else(|| PyTypeError::new_err(MEMORY_GET_SEGMENT_USED_SIZE_MSG))?
+            .to_object(py))
     }
 }
 

--- a/src/cairo_runner.rs
+++ b/src/cairo_runner.rs
@@ -35,9 +35,9 @@ pub struct PyCairoRunner {
 impl PyCairoRunner {
     #[new]
     pub fn new(path: String, entrypoint: String, layout: Option<String>) -> PyResult<Self> {
-        let program = Program::new(Path::new(&path), &entrypoint).map_err(to_py_error)?;
+        let program = Program::from_file(Path::new(&path), &entrypoint).map_err(to_py_error)?;
         let cairo_runner =
-            CairoRunner::new(&program, layout.unwrap_or_else(|| "plain".to_string()))
+            CairoRunner::new(&program, &layout.unwrap_or_else(|| "plain".to_string()))
                 .map_err(to_py_error)?;
 
         let struct_types = program


### PR DESCRIPTION
this PR depends on https://github.com/lambdaclass/cairo-rs/pull/545 to work, since that PR exposes the required method in VM core