### PR TITLE
Expose function add_memory_segment in SegmentManager

### DIFF
--- a/src/memory_segments.rs
+++ b/src/memory_segments.rs
@@ -84,6 +84,12 @@ impl PySegmentManager {
             .map(|x| PyMaybeRelocatable::from(x).to_object(py))
             .map_err(to_py_error)
     }
+
+    pub fn add_temporary_segment(&mut self) -> PyResult<PyRelocatable> {
+        Ok(PyRelocatable::from(
+            self.vm.borrow_mut().add_temporary_segment(),
+        ))
+    }
 }
 
 #[cfg(test)]
@@ -209,5 +215,15 @@ mod test {
                 .unwrap()
                 .is_none());
         });
+    }
+
+    #[test]
+    fn add_temporary_segment_test() {
+        let mut vm = PyVM::new(
+            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+            false,
+        );
+        let mut segments = PySegmentManager::new(&mut vm);
+        assert!(segments.add_temporary_segment().is_ok());
     }
 }

--- a/src/memory_segments.rs
+++ b/src/memory_segments.rs
@@ -229,7 +229,8 @@ mod test {
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             false,
         );
-        let mut segments = PySegmentManager::new(&mut vm);
+        let memory = PyMemory::new(&vm);
+        let mut segments = PySegmentManager::new(&mut vm, memory);
         assert!(segments.add_temporary_segment().is_ok());
     }
 }


### PR DESCRIPTION
This PR depends on https://github.com/lambdaclass/cairo-rs/pull/556, that exposes the required method from memory_segments.rs