### PR TITLE
Add relocation rule method and `end_run` in `fn cairo_run_py`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ default = ["pyo3/num-bigint", "pyo3/auto-initialize"]
 
 [dependencies]
 pyo3 = { version = "0.16.5" }
-cairo-rs = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "9753135843aaae4ba67855e6b652553d5f3809cf" }
+cairo-rs = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "0af2ef604d3831ef19755e0a9f6f9089c3c6e0c7" }
 num-bigint = "0.4"
 lazy_static = "1.4.0"
 

--- a/cairo_programs/relocate_segments.cairo
+++ b/cairo_programs/relocate_segments.cairo
@@ -17,6 +17,7 @@ func main():
     # Create temporary_array in a temporary segment
     local temporary_array : felt*
     %{
+        # TEST
         ids.temporary_array = segments.add_temp_segment()
     %}
 

--- a/cairo_programs/relocate_segments.cairo
+++ b/cairo_programs/relocate_segments.cairo
@@ -1,0 +1,45 @@
+from starkware.cairo.common.segments import relocate_segment
+from starkware.cairo.common.alloc import alloc
+
+func relocate_segment2(src_ptr : felt*, dest_ptr : felt*):
+    %{ 
+        # TEST
+        memory.add_relocation_rule(src_ptr=ids.src_ptr, dest_ptr=ids.dest_ptr) 
+    %}
+
+    # Add a verifier side assert that src_ptr and dest_ptr are indeed equal.
+    assert src_ptr = dest_ptr
+    return ()
+end
+
+
+func main():
+    alloc_locals
+    # Create temporary_array in a temporary segment
+    local temporary_array : felt*
+    %{
+        ids.temporary_array = segments.add_temp_segment()
+    %}
+
+    # Insert values into temporary_array
+    assert temporary_array[0] = 1
+    assert temporary_array[1] = 2
+
+    # Create array
+    let (array : felt*) = alloc()
+
+    # Insert values into array
+    assert array[0] = 50
+    assert array[1] = 51
+
+    # Realocate temporary_array into the array segment
+    relocate_segment2(src_ptr=temporary_array, dest_ptr=array)
+
+    # Assert that the realocated temporary_array gets their values from the array segment
+    assert temporary_array[0] = 50
+    assert temporary_array[1] = 51
+    assert array[2] = 52
+    assert temporary_array[2] = 52
+
+    return ()
+end

--- a/cairo_programs/relocate_segments.cairo
+++ b/cairo_programs/relocate_segments.cairo
@@ -1,7 +1,6 @@
-from starkware.cairo.common.segments import relocate_segment
 from starkware.cairo.common.alloc import alloc
 
-func relocate_segment2(src_ptr : felt*, dest_ptr : felt*):
+func relocate_segment(src_ptr : felt*, dest_ptr : felt*):
     %{ 
         # TEST
         memory.add_relocation_rule(src_ptr=ids.src_ptr, dest_ptr=ids.dest_ptr) 
@@ -33,7 +32,7 @@ func main():
     assert array[1] = 51
 
     # Realocate temporary_array into the array segment
-    relocate_segment2(src_ptr=temporary_array, dest_ptr=array)
+    relocate_segment(src_ptr=temporary_array, dest_ptr=array)
 
     # Assert that the realocated temporary_array gets their values from the array segment
     assert temporary_array[0] = 50

--- a/cairo_programs/relocate_segments_with_offset.cairo
+++ b/cairo_programs/relocate_segments_with_offset.cairo
@@ -1,0 +1,44 @@
+from starkware.cairo.common.alloc import alloc
+
+func relocate_segment(src_ptr : felt*, dest_ptr : felt*):
+    %{ 
+        # TEST
+        memory.add_relocation_rule(src_ptr=ids.src_ptr, dest_ptr=ids.dest_ptr) 
+    %}
+
+    # Add a verifier side assert that src_ptr and dest_ptr are indeed equal.
+    assert src_ptr = dest_ptr
+    return ()
+end
+
+func main():
+    alloc_locals
+    # Create temporary_array_no_offset in a temporary segment
+    local temporary_array : felt*
+
+    %{
+        # TEST
+        ids.temporary_array = segments.add_temp_segment()
+    %}
+
+    # Insert values into temporary_array_no_offset
+    assert temporary_array[0] = 1
+    assert temporary_array[1] = 2
+
+    # Create array
+    let (array : felt*) = alloc()
+
+    # Insert values into array
+    assert array[5] = 5
+    assert array[6] = 6
+
+
+    # Realocate temporary_array into the array pointer + 5
+    relocate_segment(src_ptr=temporary_array, dest_ptr=(array + 5))
+
+    # Assert that the relocated temporary_array gets their values from the array segment
+    assert temporary_array[0] = 5
+    assert temporary_array[1] = 6
+
+    return ()
+end

--- a/hints_tests.py
+++ b/hints_tests.py
@@ -70,4 +70,5 @@ if __name__ == "__main__":
     test_program("blake2s_felt")
     test_program("blake2s_integration_tests")
     test_program("relocate_segments")
+    test_program("relocate_segments_with_offset")
     print("\nAll test have passed")

--- a/hints_tests.py
+++ b/hints_tests.py
@@ -69,4 +69,5 @@ if __name__ == "__main__":
     test_program("blake2s_finalize")
     test_program("blake2s_felt")
     test_program("blake2s_integration_tests")
+    test_program("relocate_segments")
     print("\nAll test have passed")

--- a/src/cairo_runner.rs
+++ b/src/cairo_runner.rs
@@ -104,6 +104,15 @@ impl PyCairoRunner {
         }
         self.run_until_pc(&end)?;
 
+        self.inner
+            .end_run(
+                false,
+                false,
+                &mut (*self.pyvm.vm).borrow_mut(),
+                &self.hint_processor,
+            )
+            .map_err(to_py_error)?;
+
         (*self.pyvm.vm)
             .borrow_mut()
             .verify_auto_deductions()

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -15,6 +15,8 @@ use std::{cell::RefCell, rc::Rc};
 const MEMORY_GET_ERROR_MSG: &str = "Failed to get value from Cairo memory";
 const MEMORY_SET_ERROR_MSG: &str = "Failed to set value to Cairo memory";
 const MEMORY_GET_RANGE_ERROR_MSG: &str = "Failed to call get_range method from Cairo memory";
+const MEMORY_ADD_RELOCATION_RULE_ERROR_MSG: &str =
+    "Failed to call add_relocation_rule method from Cairo memory";
 
 #[pyclass(unsendable)]
 #[derive(Clone)]
@@ -68,6 +70,17 @@ impl PyMemory {
             .map(Into::<PyMaybeRelocatable>::into)
             .collect::<Vec<PyMaybeRelocatable>>()
             .to_object(py))
+    }
+
+    pub fn add_relocation_rule(
+        &self,
+        src_ptr: PyRelocatable,
+        dest_ptr: PyRelocatable,
+    ) -> Result<(), PyErr> {
+        self.vm
+            .borrow_mut()
+            .add_relocation_rule(Relocatable::from(&src_ptr), Relocatable::from(&dest_ptr))
+            .map_err(|_| PyTypeError::new_err(MEMORY_ADD_RELOCATION_RULE_ERROR_MSG))
     }
 }
 

--- a/src/memory_segments.rs
+++ b/src/memory_segments.rs
@@ -91,7 +91,7 @@ impl PySegmentManager {
             .map_err(to_py_error)
     }
 
-    pub fn add_temporary_segment(&mut self) -> PyResult<PyRelocatable> {
+    pub fn add_temp_segment(&mut self) -> PyResult<PyRelocatable> {
         Ok(PyRelocatable::from(
             self.vm.borrow_mut().add_temporary_segment(),
         ))
@@ -224,13 +224,13 @@ mod test {
     }
 
     #[test]
-    fn add_temporary_segment_test() {
+    fn add_temp_segment_test() {
         let mut vm = PyVM::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             false,
         );
         let memory = PyMemory::new(&vm);
         let mut segments = PySegmentManager::new(&mut vm, memory);
-        assert!(segments.add_temporary_segment().is_ok());
+        assert!(segments.add_temp_segment().is_ok());
     }
 }


### PR DESCRIPTION
# Add `Memory.memory.add_relocation_rule()` method and `end_run` in `fn cairo_run_py`

* Add `Memory.memory.add_relocation_rule()` method
* Add integration test
* Add `end_run` in `fn cairo_run_py`