### PR TITLE
Expose segments

### DIFF
--- a/src/cairo_runner.rs
+++ b/src/cairo_runner.rs
@@ -1,4 +1,6 @@
 use crate::{
+    memory::PyMemory,
+    memory_segments::PySegmentManager,
     relocatable::{PyMaybeRelocatable, PyRelocatable},
     utils::to_py_error,
     vm_core::PyVM,
@@ -142,6 +144,10 @@ impl PyCairoRunner {
     pub fn initialize_segments(&mut self) {
         self.inner
             .initialize_segments(&mut self.pyvm.vm.borrow_mut(), None)
+    }
+
+    pub fn segments(&self) -> PySegmentManager {
+        PySegmentManager::new(&self.pyvm, PyMemory::new(&self.pyvm))
     }
 
     pub fn run_until_pc(&mut self, address: &PyRelocatable) -> PyResult<()> {


### PR DESCRIPTION
This PR adds a function to expose the PySegmentManager to Python. This is required since[ we need that SegmentManager in the starknet code.](https://github.com/starkware-libs/cairo-lang/blob/f951a669e264796d53bf7a3cfd23d5bc1f6e54b8/src/starkware/starknet/business_logic/execution/execute_entry_point.py#L208)