### PR TITLE
Initialize function runner py cairo runner

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ default = ["pyo3/num-bigint", "pyo3/auto-initialize"]
 
 [dependencies]
 pyo3 = { version = "0.16.5" }
-cairo-rs = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "bf20daf372371ca2af1012d868971d475748d69c" }
+cairo-rs = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "9753135843aaae4ba67855e6b652553d5f3809cf" }
 num-bigint = "0.4"
 lazy_static = "1.4.0"
 

--- a/src/cairo_runner.rs
+++ b/src/cairo_runner.rs
@@ -348,6 +348,13 @@ impl PyCairoRunner {
             .insert_value(&key.into(), value)
             .map_err(to_py_error)
     }
+
+    // Initialize all the builtins and segments.
+    pub fn initialize_function_runner(&mut self) -> PyResult<()> {
+        self.inner
+            .initialize_function_runner(&mut self.pyvm.vm.borrow_mut())
+            .map_err(to_py_error)
+    }
 }
 
 #[pyclass]

--- a/src/cairo_runner.rs
+++ b/src/cairo_runner.rs
@@ -755,4 +755,63 @@ mod test {
             runner.get_initial_fp().unwrap()
         };
     }
+
+    #[test]
+    fn initialize_function_runner() {
+        let path = "cairo_programs/fibonacci.json".to_string();
+        let program = fs::read_to_string(path).unwrap();
+        let mut runner =
+            PyCairoRunner::new(program, "main".to_string(), Some("all".to_string()), false)
+                .unwrap();
+
+        runner.initialize_function_runner().unwrap();
+
+        let expected_output: Vec<(&str, Vec<PyMaybeRelocatable>)> = vec![
+            (
+                "output",
+                vec![RelocatableValue(PyRelocatable {
+                    segment_index: 2,
+                    offset: 0,
+                })],
+            ),
+            (
+                "pedersen",
+                vec![RelocatableValue(PyRelocatable {
+                    segment_index: 3,
+                    offset: 0,
+                })],
+            ),
+            (
+                "range_check",
+                vec![RelocatableValue(PyRelocatable {
+                    segment_index: 4,
+                    offset: 0,
+                })],
+            ),
+            (
+                "bitwise",
+                vec![RelocatableValue(PyRelocatable {
+                    segment_index: 5,
+                    offset: 0,
+                })],
+            ),
+            (
+                "ec_op",
+                vec![RelocatableValue(PyRelocatable {
+                    segment_index: 6,
+                    offset: 0,
+                })],
+            ),
+        ];
+
+        Python::with_gil(|py| {
+            assert_eq!(
+                runner
+                    .get_builtins_initial_stack(py)
+                    .extract::<Vec<(&str, Vec<PyMaybeRelocatable>)>>(py)
+                    .unwrap(),
+                expected_output
+            );
+        });
+    }
 }


### PR DESCRIPTION
# PyCairoRunner::initialize_function_runner()

This PR adds the `PyCairoRunner::initialize_function_runner()` method.

# ~~MERGE AFTER [#585 IN CAIRO-RS](https://github.com/lambdaclass/cairo-rs/pull/585)~~

# TO DO

- [x] Update cairo-rs commit hash in `Cargo.toml`.