### PR TITLE
Return only program builtins

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ default = ["pyo3/num-bigint", "pyo3/auto-initialize"]
 
 [dependencies]
 pyo3 = { version = "0.16.5" }
-cairo-rs = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "9753135843aaae4ba67855e6b652553d5f3809cf" }
+cairo-rs = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "8e7d6f9c0e07dc07e827ebf8ae4e9c41f23e95d5" }
 num-bigint = "0.4"
 lazy_static = "1.4.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ default = ["pyo3/num-bigint", "pyo3/auto-initialize"]
 
 [dependencies]
 pyo3 = { version = "0.16.5" }
-cairo-rs = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "8e7d6f9c0e07dc07e827ebf8ae4e9c41f23e95d5" }
+cairo-rs = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "c0bf03564b84f13749f4dc34e6ec753c131c16fc" }
 num-bigint = "0.4"
 lazy_static = "1.4.0"
 

--- a/get_builtins_initial_stack.py
+++ b/get_builtins_initial_stack.py
@@ -7,12 +7,12 @@ def new_runner(program_name: str):
 def test_program(program_name: str):
     runner = new_runner(program_name)
     
-    builtins_initial_stack = runner.get_builtins_initial_stack()
+    builtins_initial_stack = runner.get_program_builtins_initial_stack()
     assert builtins_initial_stack == [], 'Initial stack should be empty.'
     
     runner.cairo_run(False)
     
-    builtins_final_stack = runner.get_builtins_initial_stack()
+    builtins_final_stack = runner.get_program_builtins_initial_stack()
     
     expected_output = [('range_check', [(2, 0)])]
     assert str(builtins_final_stack) == str(expected_output)

--- a/src/cairo_runner.rs
+++ b/src/cairo_runner.rs
@@ -211,7 +211,7 @@ impl PyCairoRunner {
                 )
             })
             .filter(|(builtin_name, _initial_stack)| {
-                self.inner.get_program().builtins.contains(builtin_name)
+                self.inner.get_program_builtins().contains(builtin_name)
             })
             .collect::<Vec<(&String, Vec<PyMaybeRelocatable>)>>()
             .to_object(py)

--- a/src/cairo_runner.rs
+++ b/src/cairo_runner.rs
@@ -504,17 +504,12 @@ mod test {
 
         Python::with_gil(|py| {
             assert_eq!(
-                            runner
-            <<<<<<< HEAD
-                                .get_program_builtins_initial_stack(py)
-                                .extract::<Vec<(&str, Vec<PyMaybeRelocatable>)>>(py)
-            =======
-                                .get_builtins_initial_stack(py)
-                                .extract::<Vec<Vec<PyMaybeRelocatable>>>(py)
-            >>>>>>> e0198e7c47ac6563111bbc3ef7f4b8a6bf7469a5
-                                .unwrap(),
-                            expected_output
-                        );
+                runner
+                    .get_program_builtins_initial_stack(py)
+                    .extract::<Vec<Vec<PyMaybeRelocatable>>>(py)
+                    .unwrap(),
+                expected_output
+            );
         });
     }
 
@@ -769,13 +764,15 @@ mod test {
 
         runner.initialize_function_runner().unwrap();
 
+        let expected_output: Vec<Vec<PyMaybeRelocatable>> = vec![];
+
         Python::with_gil(|py| {
             assert_eq!(
                 runner
                     .get_program_builtins_initial_stack(py)
                     .extract::<Vec<Vec<PyMaybeRelocatable>>>(py)
                     .unwrap(),
-                vec![]
+                expected_output
             );
         });
     }

--- a/src/cairo_runner.rs
+++ b/src/cairo_runner.rs
@@ -769,51 +769,13 @@ mod test {
 
         runner.initialize_function_runner().unwrap();
 
-        let expected_output: Vec<(&str, Vec<PyMaybeRelocatable>)> = vec![
-            (
-                "output",
-                vec![RelocatableValue(PyRelocatable {
-                    segment_index: 2,
-                    offset: 0,
-                })],
-            ),
-            (
-                "pedersen",
-                vec![RelocatableValue(PyRelocatable {
-                    segment_index: 3,
-                    offset: 0,
-                })],
-            ),
-            (
-                "range_check",
-                vec![RelocatableValue(PyRelocatable {
-                    segment_index: 4,
-                    offset: 0,
-                })],
-            ),
-            (
-                "bitwise",
-                vec![RelocatableValue(PyRelocatable {
-                    segment_index: 5,
-                    offset: 0,
-                })],
-            ),
-            (
-                "ec_op",
-                vec![RelocatableValue(PyRelocatable {
-                    segment_index: 6,
-                    offset: 0,
-                })],
-            ),
-        ];
-
         Python::with_gil(|py| {
             assert_eq!(
                 runner
                     .get_program_builtins_initial_stack(py)
                     .extract::<Vec<(&str, Vec<PyMaybeRelocatable>)>>(py)
                     .unwrap(),
-                expected_output
+                vec![]
             );
         });
     }

--- a/src/cairo_runner.rs
+++ b/src/cairo_runner.rs
@@ -194,7 +194,7 @@ impl PyCairoRunner {
         self.pyvm.vm.borrow_mut().add_memory_segment().into()
     }
 
-    pub fn get_builtins_initial_stack(&self, py: Python) -> PyObject {
+    pub fn get_program_builtins_initial_stack(&self, py: Python) -> PyObject {
         self.pyvm
             .vm
             .borrow_mut()
@@ -209,6 +209,9 @@ impl PyCairoRunner {
                         .map(Into::<PyMaybeRelocatable>::into)
                         .collect::<Vec<PyMaybeRelocatable>>(),
                 )
+            })
+            .filter(|(builtin_name, _initial_stack)| {
+                self.inner.get_program().builtins.contains(builtin_name)
             })
             .collect::<Vec<(&String, Vec<PyMaybeRelocatable>)>>()
             .to_object(py)
@@ -507,7 +510,7 @@ mod test {
         Python::with_gil(|py| {
             assert_eq!(
                 runner
-                    .get_builtins_initial_stack(py)
+                    .get_program_builtins_initial_stack(py)
                     .extract::<Vec<(&str, Vec<PyMaybeRelocatable>)>>(py)
                     .unwrap(),
                 expected_output
@@ -807,7 +810,7 @@ mod test {
         Python::with_gil(|py| {
             assert_eq!(
                 runner
-                    .get_builtins_initial_stack(py)
+                    .get_program_builtins_initial_stack(py)
                     .extract::<Vec<(&str, Vec<PyMaybeRelocatable>)>>(py)
                     .unwrap(),
                 expected_output


### PR DESCRIPTION
This PR filter the initial stacks we return because we only need the ones contained in the program builtins.