### PR TITLE
Refactor run_from_entrypoint()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ default = ["pyo3/num-bigint", "pyo3/auto-initialize"]
 
 [dependencies]
 pyo3 = { version = "0.16.5" }
-cairo-rs = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "9753135843aaae4ba67855e6b652553d5f3809cf" }
+cairo-rs = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "29c64a662e27f0ec725ad6b9189b84c276f1b590" }
 num-bigint = "0.4"
 lazy_static = "1.4.0"
 

--- a/src/cairo_runner.rs
+++ b/src/cairo_runner.rs
@@ -50,7 +50,8 @@ impl PyCairoRunner {
         layout: Option<String>,
         proof_mode: bool,
     ) -> PyResult<Self> {
-        let program = Program::from_reader(program.as_bytes(), &entrypoint).map_err(to_py_error)?;
+        let program =
+            Program::from_reader(program.as_bytes(), Some(&entrypoint)).map_err(to_py_error)?;
         let cairo_runner = CairoRunner::new(
             &program,
             &layout.unwrap_or_else(|| "plain".to_string()),
@@ -379,7 +380,12 @@ impl PyCairoRunner {
         self.run_until_pc(&PyRelocatable::from(end))?;
 
         self.inner
-            .end_run(true, false, &mut self.pyvm.vm.borrow_mut())
+            .end_run(
+                true,
+                false,
+                &mut self.pyvm.vm.borrow_mut(),
+                &self.hint_processor,
+            )
             .map_err(to_py_error)?;
 
         if verify_secure.unwrap_or(true) {


### PR DESCRIPTION
This PR refactors `run_from_entrypoint`. At the moment this method internally called `cairo-rs`'s `run_from_entrypoint`, which resulted in an `UnknownHintError` when executing the function in the StarkNet environment.

Depends on https://github.com/lambdaclass/cairo-rs/pull/595