### PR TITLE
Implement `PyCairoRunner::add_additional_hash_builtin()`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ default = ["pyo3/num-bigint", "pyo3/auto-initialize"]
 
 [dependencies]
 pyo3 = { version = "0.16.5" }
-cairo-rs = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "4f36aaf46dea8cac158d0da5e80537388e048c01" }
+cairo-rs = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "67cc753416c5c900155eacbaf620529ee5620b70" }
 num-bigint = "0.4"
 lazy_static = "1.4.0"
 

--- a/src/cairo_runner.rs
+++ b/src/cairo_runner.rs
@@ -1537,7 +1537,9 @@ mod test {
             .unwrap();
 
             assert!(runner
-                .add_additional_hash_builtin(Some(py.eval("", None, None).unwrap().to_object(py)))
+                .add_additional_hash_builtin(Some(
+                    py.eval("lambda: None", None, None).unwrap().to_object(py)
+                ))
                 .is_err());
         });
     }


### PR DESCRIPTION
Depends on [#612](https://github.com/lambdaclass/cairo-rs/pull/612).