### PR TITLE
Change PyIds handling of pointer types

### DIFF
--- a/src/ids.rs
+++ b/src/ids.rs
@@ -118,7 +118,7 @@ impl PyIds {
                 return Ok(PyTypedId {
                     vm: self.vm.clone(),
                     hint_value,
-                    cairo_type: cairo_type.to_string(),
+                    cairo_type: clear_ref,
                     struct_types: Rc::clone(&self.struct_types),
                 }
                 .into_py(py));


### PR DESCRIPTION
Previously PyIds passed the pointer cairo type to PyTypedId, causing a "Failed to get struct type" error. This PR also adds a unit test for that case.