### PR TITLE
Add unit tests to cairo_runner

### DIFF
--- a/src/cairo_runner.rs
+++ b/src/cairo_runner.rs
@@ -1511,6 +1511,21 @@ mod test {
             .expect("Call to PyCairoRunner::cairo_run_py() failed.");
     }
 
+    #[test]
+    fn set_bad_entrypoint_on_new() {
+        let path = "cairo_programs/fibonacci.json".to_string();
+        eprintln!("set");
+        let program = fs::read_to_string(path).unwrap();
+        let result = PyCairoRunner::new(
+            program,
+            Some(" non-existent entrypoint".to_string()),
+            Some("small".to_string()),
+            false,
+        );
+
+        assert!(result.is_err());
+    }
+
     /// Test that `PyCairoRunner::get()` works as intended.
     #[test]
     fn get() {

--- a/src/cairo_runner.rs
+++ b/src/cairo_runner.rs
@@ -1968,4 +1968,27 @@ mod test {
             assert_eq!(result, Ok(&expected) as Result<&BigInt, &PyRelocatable>);
         });
     }
+
+    #[test]
+    fn get_return_values_out_of_bounds() {
+        let path = String::from("cairo_programs/fibonacci.json");
+        let program = fs::read_to_string(path).unwrap();
+        let mut runner = PyCairoRunner::new(
+            program,
+            Some("main".to_string()),
+            Some("small".to_string()),
+            false,
+        )
+        .unwrap();
+
+        runner
+            .cairo_run_py(false, None, None, None, None, None)
+            .expect("Call to PyCairoRunner::cairo_run_py() failed.");
+
+        Python::with_gil(|py| {
+            let oob_error = runner.get_return_values(100, py);
+
+            assert!(oob_error.is_err());
+        });
+    }
 }

--- a/src/cairo_runner.rs
+++ b/src/cairo_runner.rs
@@ -1976,6 +1976,32 @@ mod test {
     }
 
     #[test]
+    fn get_execution_resources() {
+        let path = String::from("cairo_programs/array_sum.json");
+        let program = fs::read_to_string(path).unwrap();
+        let mut runner = PyCairoRunner::new(
+            program,
+            Some("main".to_string()),
+            Some("small".to_string()),
+            false,
+        )
+        .unwrap();
+
+        let result = runner.cairo_run_py(false, None, None, None, None, None);
+
+        assert!(result.is_ok());
+
+        let exec_res = runner.get_execution_resources().unwrap();
+
+        assert_eq!(exec_res.n_steps(), 0);
+        assert_eq!(exec_res.n_memory_holes(), 0);
+        assert_eq!(
+            exec_res.builtin_instance_counter(),
+            HashMap::from([("output_builtin".to_string(), 1)])
+        );
+    }
+
+    #[test]
     fn mark_as_accessed_run_not_finished() {
         let path = String::from("cairo_programs/fibonacci.json");
         let program = fs::read_to_string(path).unwrap();

--- a/src/cairo_runner.rs
+++ b/src/cairo_runner.rs
@@ -1174,6 +1174,42 @@ mod test {
     }
 
     #[test]
+    fn run_from_entrypoint_with_string_name() {
+        let path = "cairo_programs/not_main.json".to_string();
+        let program = fs::read_to_string(path).unwrap();
+        let mut runner = PyCairoRunner::new(
+            program,
+            Some("main".to_string()),
+            Some("plain".to_string()),
+            false,
+        )
+        .unwrap();
+
+        // Without `runner.initialize()`, an uninitialized error is returned.
+        // With `runner.initialize()`, an invalid memory assignment is returned...
+        //   Maybe it has to do with `initialize_main_entrypoint()` called from `initialize()`?
+        runner.initialize_segments();
+
+        Python::with_gil(|py| {
+            let result = runner.run_from_entrypoint(
+                py,
+                py.eval("'not_main'", None, None).unwrap(),
+                Vec::<&PyAny>::new().to_object(py),
+                None,
+                None,
+                Some(false),
+                None,
+                None,
+            );
+            // using a named entrypoint in run_from_entrypoint is not implemented yet
+            assert_eq!(
+                format!("{:?}", result),
+                format!("{:?}", Err::<(), PyErr>(PyNotImplementedError::new_err(())))
+            );
+        });
+    }
+
+    #[test]
     fn run_from_entrypoint_without_args_set_hint_locals() {
         let path = "cairo_programs/not_main.json".to_string();
         let program = fs::read_to_string(path).unwrap();

--- a/src/cairo_runner.rs
+++ b/src/cairo_runner.rs
@@ -1899,6 +1899,25 @@ mod test {
     }
 
     #[test]
+    fn cairo_run_with_nonexistent_trace_file() {
+        let path = String::from("cairo_programs/fibonacci.json");
+        let program = fs::read_to_string(path).unwrap();
+        let mut runner = PyCairoRunner::new(
+            program,
+            Some("main".to_string()),
+            Some("small".to_string()),
+            false,
+        )
+        .unwrap();
+
+        let trace_path = "cairo_programs";
+
+        let result = runner.cairo_run_py(false, Some(trace_path), None, None, None, None);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
     fn cairo_run_with_memory_file() {
         let path = String::from("cairo_programs/fibonacci.json");
         let program = fs::read_to_string(path).unwrap();
@@ -1920,6 +1939,25 @@ mod test {
         assert!(fs::canonicalize(memory_path).is_ok());
 
         _ = fs::remove_file(memory_path);
+    }
+
+    #[test]
+    fn cairo_run_with_nonexistent_memory_file() {
+        let path = String::from("cairo_programs/fibonacci.json");
+        let program = fs::read_to_string(path).unwrap();
+        let mut runner = PyCairoRunner::new(
+            program,
+            Some("main".to_string()),
+            Some("small".to_string()),
+            false,
+        )
+        .unwrap();
+
+        let memory_path = "cairo_programs";
+
+        let result = runner.cairo_run_py(false, None, Some(memory_path), None, None, None);
+
+        assert!(result.is_err());
     }
 
     #[test]

--- a/src/cairo_runner.rs
+++ b/src/cairo_runner.rs
@@ -36,7 +36,7 @@ const FAILED_TO_GET_INITIAL_FP: &str = "Failed to get initial segment";
 #[pyo3(name = "CairoRunner")]
 pub struct PyCairoRunner {
     inner: CairoRunner,
-    pyvm: PyVM,
+    pub(crate) pyvm: PyVM,
     hint_processor: BuiltinHintProcessor,
     hint_locals: HashMap<String, PyObject>,
     struct_types: Rc<HashMap<String, HashMap<String, Member>>>,
@@ -98,6 +98,7 @@ impl PyCairoRunner {
         }
 
         let end = self.initialize()?;
+
         if let Some(locals) = hint_locals {
             self.hint_locals = locals
         }
@@ -372,6 +373,7 @@ impl PyCairoRunner {
             let args = self
                 .gen_typed_args(py, args.to_object(py))
                 .map_err(to_py_error)?;
+
             let mut stack = Vec::new();
             for arg in args.extract::<Vec<&PyAny>>(py)? {
                 let arg: MaybeRelocatable = arg.extract::<PyMaybeRelocatable>()?.into();
@@ -711,6 +713,8 @@ mod test {
             TypePointer,
             TypeFelt,
             TypeStruct,
+            // this value is added to test invalid types
+            BigInt,
         }
 
         #[pyclass]
@@ -1139,6 +1143,37 @@ mod test {
     }
 
     #[test]
+    fn failed_to_get_segment_used_size() {
+        let path = "cairo_programs/fibonacci.json".to_string();
+        let program = fs::read_to_string(path).unwrap();
+        let mut runner =
+            PyCairoRunner::new(program, Some("main".to_string()), None, false).unwrap();
+        runner
+            .cairo_run_py(false, None, None, None, None, None)
+            .unwrap();
+
+        Python::with_gil(|py| assert!(runner.get_segment_used_size(100, py).is_err()));
+    }
+
+    #[test]
+    fn cairo_run_py_with_hint_locals() {
+        let path = "cairo_programs/fibonacci.json".to_string();
+        let program = fs::read_to_string(path).unwrap();
+        let hint_locals = Some(HashMap::from([(
+            "__find_element_max_size".to_string(),
+            Python::with_gil(|py| -> PyObject { 100.to_object(py) }),
+        )]));
+        let mut runner =
+            PyCairoRunner::new(program, Some("main".to_string()), None, false).unwrap();
+
+        runner
+            .cairo_run_py(false, None, None, hint_locals, None, None)
+            .unwrap();
+
+        Python::with_gil(|py| assert!(runner.get_segment_used_size(100, py).is_err()));
+    }
+
+    #[test]
     fn run_from_entrypoint_without_args() {
         let path = "cairo_programs/not_main.json".to_string();
         let program = fs::read_to_string(path).unwrap();
@@ -1168,6 +1203,129 @@ mod test {
                     None,
                 )
                 .unwrap();
+        });
+    }
+
+    #[test]
+    fn run_from_entrypoint_with_false_apply_module_to_args_and_false_typed_args() {
+        let path = "cairo_programs/not_main.json".to_string();
+        let program = fs::read_to_string(path).unwrap();
+        let mut runner = PyCairoRunner::new(
+            program,
+            Some("main".to_string()),
+            Some("plain".to_string()),
+            false,
+        )
+        .unwrap();
+
+        // Without `runner.initialize()`, an uninitialized error is returned.
+        // With `runner.initialize()`, an invalid memory assignment is returned...
+        //   Maybe it has to do with `initialize_main_entrypoint()` called from `initialize()`?
+        runner.initialize_segments();
+
+        Python::with_gil(|py| {
+            let args = vec![
+                Into::<PyMaybeRelocatable>::into(MaybeRelocatable::from((0, 0))).to_object(py),
+                Into::<PyMaybeRelocatable>::into(MaybeRelocatable::from((0, 1))).to_object(py),
+            ]
+            .to_object(py);
+
+            runner
+                .run_from_entrypoint(
+                    py,
+                    py.eval("0", None, None).unwrap(),
+                    args,
+                    None,
+                    None,
+                    Some(false),
+                    None,
+                    Some(false),
+                )
+                .unwrap();
+        });
+    }
+
+    #[test]
+    fn run_from_entrypoint_with_false_apply_module_to_args_and_true_typed_args() {
+        let path = "cairo_programs/not_main.json".to_string();
+        let program = fs::read_to_string(path).unwrap();
+        let mut runner = PyCairoRunner::new(
+            program,
+            Some("main".to_string()),
+            Some("plain".to_string()),
+            false,
+        )
+        .unwrap();
+
+        // Without `runner.initialize()`, an uninitialized error is returned.
+        // With `runner.initialize()`, an invalid memory assignment is returned...
+        //   Maybe it has to do with `initialize_main_entrypoint()` called from `initialize()`?
+        runner.initialize_segments();
+
+        Python::with_gil(|py| {
+            let args = MyIterator {
+                iter: Box::new(
+                    vec![
+                        PyMaybeRelocatable::from(bigint!(0)).to_object(py),
+                        PyMaybeRelocatable::from(bigint!(2)).to_object(py),
+                    ]
+                    .into_iter(),
+                ),
+                types: vec![PyType::TypeFelt, PyType::TypeFelt],
+            }
+            .into_py(py);
+
+            runner
+                .run_from_entrypoint(
+                    py,
+                    py.eval("0", None, None).unwrap(),
+                    args,
+                    None,
+                    None,
+                    Some(true),
+                    None,
+                    Some(false),
+                )
+                .unwrap();
+        });
+    }
+
+    #[test]
+    fn error_when_run_from_entrypoint_with_invalid_args() {
+        let path = "cairo_programs/not_main.json".to_string();
+        let program = fs::read_to_string(path).unwrap();
+        let mut runner = PyCairoRunner::new(
+            program,
+            Some("main".to_string()),
+            Some("plain".to_string()),
+            false,
+        )
+        .unwrap();
+
+        runner.initialize_segments();
+
+        Python::with_gil(|py| {
+            // invalid arguments
+            let args =
+                vec![vec![vec![
+                    Into::<PyMaybeRelocatable>::into(MaybeRelocatable::from((0, 0))).to_object(py),
+                ]
+                .to_object(py)]
+                .to_object(py)]
+                .to_object(py);
+
+            assert!(runner
+                .run_from_entrypoint(
+                    py,
+                    py.eval("0", None, None).unwrap(),
+                    args,
+                    None,
+                    None,
+                    Some(false),
+                    None,
+                    Some(false),
+                )
+                .is_err());
         });
     }
 
@@ -1493,6 +1651,21 @@ mod test {
             PyRelocatable::from((1,2)),
             runner.initial_fp().unwrap()
         };
+    }
+
+    #[test]
+    fn failed_to_get_initial_fp_test() {
+        let path = "cairo_programs/fibonacci.json".to_string();
+        let program = fs::read_to_string(path).unwrap();
+        let runner = PyCairoRunner::new(
+            program,
+            Some("main".to_string()),
+            Some(String::from("all")),
+            false,
+        )
+        .unwrap();
+
+        assert!(runner.initial_fp().is_err());
     }
 
     #[test]
@@ -1936,6 +2109,7 @@ mod test {
                 ),
                 types: vec![PyType::TypePointer, PyType::TypePointer],
             };
+
             let stack = runner.gen_typed_args(py, arg.into_py(py)).unwrap();
             let stack = stack.extract::<Vec<PyMaybeRelocatable>>(py).unwrap();
             assert_eq!(
@@ -1945,6 +2119,93 @@ mod test {
                     MaybeRelocatable::from((0, 1)).into(),
                 ]
             );
+        })
+    }
+
+    #[test]
+    fn gen_typed_args_type_struct() {
+        //For documentation on how this test works see test submodule type_samples
+
+        let program = fs::read_to_string("cairo_programs/fibonacci.json").unwrap();
+        let runner = PyCairoRunner::new(program, None, None, false).unwrap();
+        Python::with_gil(|py| {
+            let arg = MyIterator {
+                iter: Box::new(
+                    vec![
+                        MyIterator {
+                            iter: Box::new(
+                                vec![
+                                    Into::<PyMaybeRelocatable>::into(MaybeRelocatable::from((
+                                        0, 0,
+                                    )))
+                                    .to_object(py),
+                                    Into::<PyMaybeRelocatable>::into(MaybeRelocatable::from((
+                                        0, 1,
+                                    )))
+                                    .to_object(py),
+                                ]
+                                .into_iter(),
+                            ),
+                            types: vec![PyType::TypePointer, PyType::TypePointer],
+                        }
+                        .into_py(py),
+                        MyIterator {
+                            iter: Box::new(
+                                vec![
+                                    Into::<PyMaybeRelocatable>::into(MaybeRelocatable::from((
+                                        0, 0,
+                                    )))
+                                    .to_object(py),
+                                    Into::<PyMaybeRelocatable>::into(MaybeRelocatable::from((
+                                        0, 1,
+                                    )))
+                                    .to_object(py),
+                                ]
+                                .into_iter(),
+                            ),
+                            types: vec![PyType::TypePointer, PyType::TypePointer],
+                        }
+                        .into_py(py),
+                    ]
+                    .into_iter(),
+                ),
+                types: vec![PyType::TypeStruct, PyType::TypeStruct],
+            };
+
+            let stack = runner.gen_typed_args(py, arg.into_py(py)).unwrap();
+            let stack = stack.extract::<Vec<Py<PyAny>>>(py).unwrap();
+            for value in stack.iter() {
+                let stack = value.extract::<Vec<PyMaybeRelocatable>>(py).unwrap();
+                assert_eq!(
+                    stack,
+                    vec![
+                        MaybeRelocatable::from((0, 0)).into(),
+                        MaybeRelocatable::from((0, 1)).into(),
+                    ]
+                );
+            }
+        })
+    }
+
+    #[test]
+    fn error_when_gen_typed_args_with_invalid_type() {
+        //For documentation on how this test works see test submodule type_samples
+
+        let program = fs::read_to_string("cairo_programs/fibonacci.json").unwrap();
+        let runner = PyCairoRunner::new(program, None, None, false).unwrap();
+        Python::with_gil(|py| {
+            let arg = MyIterator {
+                iter: Box::new(
+                    vec![
+                        PyMaybeRelocatable::from(bigint!(0)).to_object(py),
+                        PyMaybeRelocatable::from(bigint!(2)).to_object(py),
+                    ]
+                    .into_iter(),
+                ),
+                types: vec![PyType::BigInt, PyType::BigInt],
+            };
+
+            assert!(runner.gen_typed_args(py, arg.into_py(py)).is_err());
         })
     }
 

--- a/src/cairo_runner.rs
+++ b/src/cairo_runner.rs
@@ -2093,7 +2093,6 @@ mod test {
         )
         .unwrap();
 
-        println!("{:?}", temp_dir().join("fibonacci.memory"));
         let memory_path = temp_dir().join("fibonacci.memory");
         let memory_path = memory_path.to_str().unwrap();
 

--- a/src/cairo_runner.rs
+++ b/src/cairo_runner.rs
@@ -1302,12 +1302,6 @@ mod test {
     }
 
     #[test]
-    fn run_from_entrypoint_with_one_typed_vec_arg() {
-        // One arg (typed)
-        //   vec
-    }
-
-    #[test]
     fn run_from_entrypoint_with_multiple_untyped_args() {
         // Multiple args (no typed)
         // Test that `PyCairoRunner::insert()` inserts values correctly.

--- a/src/cairo_runner.rs
+++ b/src/cairo_runner.rs
@@ -652,6 +652,7 @@ mod test {
     use crate::relocatable::PyMaybeRelocatable::RelocatableValue;
     use cairo_rs::bigint;
     use num_bigint::BigInt;
+    use std::env::temp_dir;
     use std::fs;
 
     use type_samples::*;
@@ -1974,7 +1975,10 @@ mod test {
         )
         .unwrap();
 
-        let trace_path = "cairo_programs/_temp_fibonacci.trace";
+        let trace_path = temp_dir().join("fibonacci.trace");
+        let trace_path = trace_path.to_str().unwrap();
+
+        _ = fs::remove_file(trace_path);
 
         runner
             .cairo_run_py(false, Some(trace_path), None, None, None, None)
@@ -2017,7 +2021,11 @@ mod test {
         )
         .unwrap();
 
-        let memory_path = "cairo_programs/_temp_fibonacci.memory";
+        println!("{:?}", temp_dir().join("fibonacci.memory"));
+        let memory_path = temp_dir().join("fibonacci.memory");
+        let memory_path = memory_path.to_str().unwrap();
+
+        _ = fs::remove_file(memory_path);
 
         runner
             .cairo_run_py(false, None, Some(memory_path), None, None, None)

--- a/src/cairo_runner.rs
+++ b/src/cairo_runner.rs
@@ -682,9 +682,9 @@ mod test {
         // This method returns a second object, so that we can then implement the values() method
 
         #[pymethods]
-        // This method is implemented exclusively to support arg.__annotations__
         impl MyIterator {
-            pub fn __getattr__(&self, _name: String) -> PyResult<Annotations> {
+            #[getter]
+            pub fn __annotations__(&self) -> PyResult<Annotations> {
                 Ok(Annotations {
                     0: self.types.clone(),
                 })

--- a/src/cairo_runner.rs
+++ b/src/cairo_runner.rs
@@ -2226,4 +2226,21 @@ mod test {
             assert!(oob_error.is_err());
         });
     }
+
+    #[test]
+    fn cairo_run_with_ecdsa_builtin() {
+        let path = String::from("cairo_programs/ecdsa.json");
+        let program = fs::read_to_string(path).unwrap();
+        let mut runner = PyCairoRunner::new(
+            program,
+            Some("main".to_string()),
+            Some("all".to_string()),
+            false,
+        )
+        .unwrap();
+
+        assert!(runner
+            .cairo_run_py(false, None, None, None, None, None)
+            .is_ok());
+    }
 }

--- a/src/cairo_runner.rs
+++ b/src/cairo_runner.rs
@@ -652,7 +652,6 @@ mod test {
     use crate::relocatable::PyMaybeRelocatable::RelocatableValue;
     use cairo_rs::bigint;
     use num_bigint::BigInt;
-    use pyo3::PyIterProtocol;
     use std::fs;
 
     #[test]
@@ -1644,22 +1643,13 @@ mod test {
         Where Type can be either TypeFelt, TypePointer or TypeStruct
         */
 
-        // We first create the iterable pyclass (A), implementing PyIterProtocol
+        // We first create the iterable pyclass (A)
         #[pyclass(unsendable)]
         struct MyIterator {
             iter: Box<dyn Iterator<Item = PyObject>>,
         }
 
-        #[pyproto]
-        impl PyIterProtocol for MyIterator {
-            fn __iter__(slf: PyRef<Self>) -> PyRef<Self> {
-                slf
-            }
-            fn __next__(mut slf: PyRefMut<Self>) -> Option<PyObject> {
-                slf.iter.next()
-            }
-        }
-
+        // This pyclass implements the iterator dunder methods __iter__ and __next__
         // We then implement a __getattr__ that will allow us to call Object.__annotations__ (B)
         // This method returns a second object, so that we can then implement the values() method
 
@@ -1670,6 +1660,12 @@ mod test {
                 Ok(Annotations {
                     0: vec![TypeFelt, TypeFelt],
                 })
+            }
+            fn __iter__(slf: PyRef<Self>) -> PyRef<Self> {
+                slf
+            }
+            fn __next__(mut slf: PyRefMut<Self>) -> Option<PyObject> {
+                slf.iter.next()
             }
         }
         #[pyclass(unsendable)]
@@ -1730,15 +1726,6 @@ mod test {
             iter: Box<dyn Iterator<Item = PyObject>>,
         }
 
-        #[pyproto]
-        impl PyIterProtocol for MyIterator {
-            fn __iter__(slf: PyRef<Self>) -> PyRef<Self> {
-                slf
-            }
-            fn __next__(mut slf: PyRefMut<Self>) -> Option<PyObject> {
-                slf.iter.next()
-            }
-        }
         #[pymethods]
         // This method is implemented exclusively to support arg.__annotations__
         impl MyIterator {
@@ -1746,6 +1733,12 @@ mod test {
                 Ok(Annotations {
                     0: vec![TypePointer, TypePointer],
                 })
+            }
+            fn __iter__(slf: PyRef<Self>) -> PyRef<Self> {
+                slf
+            }
+            fn __next__(mut slf: PyRefMut<Self>) -> Option<PyObject> {
+                slf.iter.next()
             }
         }
         #[pyclass(unsendable)]

--- a/src/cairo_runner.rs
+++ b/src/cairo_runner.rs
@@ -1935,4 +1935,37 @@ mod test {
         .unwrap();
         assert!(runner.mark_as_accessed((0, 0).into(), 3).is_err());
     }
+
+    #[test]
+    fn get_return_values_ok() {
+        let path = String::from("cairo_programs/fibonacci.json");
+        let program = fs::read_to_string(path).unwrap();
+        let mut runner = PyCairoRunner::new(
+            program,
+            Some("main".to_string()),
+            Some("small".to_string()),
+            false,
+        )
+        .unwrap();
+
+        runner
+            .cairo_run_py(false, None, None, None, None, None)
+            .expect("Call to PyCairoRunner::cairo_run_py() failed.");
+
+        Python::with_gil(|py| {
+            let addresses = runner
+                .get_return_values(1, py)
+                .unwrap()
+                .extract::<Vec<PyMaybeRelocatable>>(py)
+                .unwrap();
+            assert_eq!(addresses.len(), 1);
+
+            let result = match &addresses[0] {
+                PyMaybeRelocatable::Int(value) => Ok(value),
+                PyMaybeRelocatable::RelocatableValue(r) => Err(r),
+            };
+            let expected = bigint!(144);
+            assert_eq!(result, Ok(&expected) as Result<&BigInt, &PyRelocatable>);
+        });
+    }
 }

--- a/src/cairo_runner.rs
+++ b/src/cairo_runner.rs
@@ -446,14 +446,6 @@ impl PyCairoRunner {
             )
             .map_err(to_py_error)?;
 
-        for i in 0..10 {
-            println!(
-                "{}: {}",
-                i,
-                self.pyvm.vm.borrow().get_segment_used_size(i).unwrap_or(0)
-            );
-        }
-
         if verify_secure.unwrap_or(true) {
             verify_secure_runner(&self.inner, false, &mut (*self.pyvm.vm).borrow_mut())
                 .map_err(to_py_error)?;
@@ -1690,7 +1682,7 @@ mod test {
     #[test]
     fn set_bad_entrypoint_on_new() {
         let path = "cairo_programs/fibonacci.json".to_string();
-        eprintln!("set");
+
         let program = fs::read_to_string(path).unwrap();
         let result = PyCairoRunner::new(
             program,
@@ -2143,7 +2135,7 @@ mod test {
         .unwrap();
 
         runner
-            .cairo_run_py(false, None, None, None, None, None)
+            .cairo_run_py(true, None, None, None, None, None)
             .expect("Call to PyCairoRunner::cairo_run_py() failed.");
 
         Python::with_gil(|py| {

--- a/src/cairo_runner.rs
+++ b/src/cairo_runner.rs
@@ -1993,6 +1993,7 @@ mod test {
 
         let exec_res = runner.get_execution_resources().unwrap();
 
+        // n_steps is 0 because trace is disabled when trace_file is None
         assert_eq!(exec_res.n_steps(), 0);
         assert_eq!(exec_res.n_memory_holes(), 0);
         assert_eq!(

--- a/src/cairo_runner.rs
+++ b/src/cairo_runner.rs
@@ -1873,4 +1873,18 @@ mod test {
             assert_eq!(get_value(&segment, 4), None);
         });
     }
+
+    #[test]
+    fn mark_as_accessed_run_not_finished() {
+        let path = String::from("cairo_programs/fibonacci.json");
+        let program = fs::read_to_string(path).unwrap();
+        let mut runner = PyCairoRunner::new(
+            program,
+            Some("main".to_string()),
+            Some("small".to_string()),
+            false,
+        )
+        .unwrap();
+        assert!(runner.mark_as_accessed((0, 0).into(), 3).is_err());
+    }
 }

--- a/src/cairo_runner.rs
+++ b/src/cairo_runner.rs
@@ -1875,6 +1875,54 @@ mod test {
     }
 
     #[test]
+    fn cairo_run_with_trace_file() {
+        let path = String::from("cairo_programs/fibonacci.json");
+        let program = fs::read_to_string(path).unwrap();
+        let mut runner = PyCairoRunner::new(
+            program,
+            Some("main".to_string()),
+            Some("small".to_string()),
+            false,
+        )
+        .unwrap();
+
+        let trace_path = "cairo_programs/_temp_fibonacci.trace";
+
+        runner
+            .cairo_run_py(false, Some(trace_path), None, None, None, None)
+            .expect("Call to PyCairoRunner::cairo_run_py() failed.");
+
+        // We simply check if file exists
+        assert!(fs::canonicalize(trace_path).is_ok());
+
+        _ = fs::remove_file(trace_path);
+    }
+
+    #[test]
+    fn cairo_run_with_memory_file() {
+        let path = String::from("cairo_programs/fibonacci.json");
+        let program = fs::read_to_string(path).unwrap();
+        let mut runner = PyCairoRunner::new(
+            program,
+            Some("main".to_string()),
+            Some("small".to_string()),
+            false,
+        )
+        .unwrap();
+
+        let memory_path = "cairo_programs/_temp_fibonacci.memory";
+
+        runner
+            .cairo_run_py(false, None, Some(memory_path), None, None, None)
+            .expect("Call to PyCairoRunner::cairo_run_py() failed.");
+
+        // We simply check if file exists
+        assert!(fs::canonicalize(memory_path).is_ok());
+
+        _ = fs::remove_file(memory_path);
+    }
+
+    #[test]
     fn mark_as_accessed_run_not_finished() {
         let path = String::from("cairo_programs/fibonacci.json");
         let program = fs::read_to_string(path).unwrap();

--- a/src/ecdsa.rs
+++ b/src/ecdsa.rs
@@ -11,7 +11,7 @@ use pyo3::prelude::*;
 use crate::relocatable::PyRelocatable;
 
 #[pyclass(name = "Signature")]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PySignature {
     signatures: HashMap<PyRelocatable, (BigInt, BigInt)>,
 }
@@ -53,5 +53,131 @@ impl Default for PySignature {
 impl ToPyObject for PySignature {
     fn to_object(&self, py: Python<'_>) -> PyObject {
         self.clone().into_py(py)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::relocatable::PyRelocatable;
+    use num_bigint::{BigInt, Sign};
+
+    use crate::cairo_runner::PyCairoRunner;
+
+    use std::fs;
+
+    #[test]
+    fn create_empty_py_signature() {
+        PySignature::new();
+    }
+
+    #[test]
+    fn add_py_signature() {
+        let rel = PyRelocatable {
+            segment_index: 2,
+            offset: 0,
+        };
+
+        let numbers = (
+            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+        );
+
+        let mut signature = PySignature::new();
+
+        signature.add_signature(rel, numbers);
+    }
+
+    #[test]
+    fn update_py_signature() {
+        let rel = PyRelocatable {
+            segment_index: 2,
+            offset: 0,
+        };
+
+        let numbers = (
+            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 13421772]),
+            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 13421772]),
+        );
+
+        let mut signature = PySignature::new();
+        let original_signature = signature.clone();
+
+        signature.add_signature(rel, numbers);
+
+        let path = "cairo_programs/ecdsa.json".to_string();
+        let program = fs::read_to_string(path).unwrap();
+        let mut runner = PyCairoRunner::new(
+            program,
+            Some("main".to_string()),
+            Some("all".to_string()),
+            false,
+        )
+        .unwrap();
+
+        runner.initialize().expect("Failed to initialize VM");
+
+        let mut binding = runner.pyvm.vm.borrow_mut();
+        let signature_builtin = binding.get_signature_builtin().unwrap();
+
+        assert_eq!(signature.update_signature(signature_builtin), Ok(()));
+
+        assert_ne!(original_signature.signatures, signature.signatures);
+    }
+
+    #[test]
+    fn update_py_signature_with_invalid_vaue() {
+        let rel = PyRelocatable {
+            segment_index: 2,
+            offset: 0,
+        };
+
+        let numbers = (
+            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+        );
+
+        let mut signature = PySignature::new();
+
+        signature.add_signature(rel, numbers);
+
+        let path = "cairo_programs/ecdsa.json".to_string();
+        let program = fs::read_to_string(path).unwrap();
+        let mut runner = PyCairoRunner::new(
+            program,
+            Some("main".to_string()),
+            Some("all".to_string()),
+            false,
+        )
+        .unwrap();
+
+        runner.initialize().expect("Failed to initialize VM");
+
+        let mut binding = runner.pyvm.vm.borrow_mut();
+        let signature_builtin = binding.get_signature_builtin().unwrap();
+
+        assert!(signature.update_signature(signature_builtin).is_err());
+    }
+
+    #[test]
+    fn py_signature_to_py_object() {
+        let new_py_signature = PySignature::new();
+
+        Python::with_gil(|py| {
+            let py_object = new_py_signature
+                .to_object(py)
+                .extract::<PySignature>(py)
+                .unwrap();
+
+            assert_eq!(py_object, PySignature::new());
+        });
+    }
+
+    #[test]
+    fn py_signature_default() {
+        let new_py_signature = PySignature::default();
+        let empty_signatures = HashMap::new();
+
+        assert_eq!(new_py_signature.signatures, empty_signatures);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,3 +20,17 @@ fn cairo_rs_py(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<PyCairoRunner>()?;
     Ok(())
 }
+
+#[cfg(test)]
+mod test {
+    use pyo3::prelude::*;
+    use pyo3::Python;
+
+    #[test]
+    fn cairo_rs_py_test() {
+        Python::with_gil(|py| {
+            let module = PyModule::new(py, "My Module");
+            assert!(crate::cairo_rs_py(py, module.unwrap()).is_ok());
+        });
+    }
+}

--- a/src/vm_core.rs
+++ b/src/vm_core.rs
@@ -1102,7 +1102,7 @@ lista_b = [lista_a[k] for k in range(2)]";
 
     #[test]
     fn run_hint_with_static_locals() {
-        let mut vm = PyVM::new(
+        let vm = PyVM::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             false,
             Vec::new(),
@@ -1139,7 +1139,7 @@ lista_b = [lista_a[k] for k in range(2)]";
 
     #[test]
     fn run_hint_with_static_locals_shouldnt_change_its_value() {
-        let mut vm = PyVM::new(
+        let vm = PyVM::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             false,
             Vec::new(),
@@ -1174,7 +1174,7 @@ lista_b = [lista_a[k] for k in range(2)]";
 
     #[test]
     fn run_hint_with_static_locals_shouldnt_affect_scope_or_hint_locals() {
-        let mut vm = PyVM::new(
+        let vm = PyVM::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             false,
             Vec::new(),

--- a/src/vm_core.rs
+++ b/src/vm_core.rs
@@ -300,7 +300,7 @@ pub(crate) fn update_scope_hint_locals(
 
 #[cfg(test)]
 mod test {
-    use crate::{relocatable::PyMaybeRelocatable, vm_core::PyVM};
+    use crate::{cairo_runner::PyCairoRunner, relocatable::PyMaybeRelocatable, vm_core::PyVM};
     use cairo_rs::{
         bigint,
         hint_processor::{
@@ -313,11 +313,14 @@ mod test {
             exec_scope::ExecutionScopes,
             relocatable::{MaybeRelocatable, Relocatable},
         },
-        vm::errors::{exec_scope_errors::ExecScopeError, vm_errors::VirtualMachineError},
+        vm::{
+            errors::{exec_scope_errors::ExecScopeError, vm_errors::VirtualMachineError},
+            runners::builtin_runner::SignatureBuiltinRunner,
+        },
     };
     use num_bigint::{BigInt, Sign};
     use pyo3::{PyObject, Python, ToPyObject};
-    use std::{any::Any, collections::HashMap, rc::Rc};
+    use std::{any::Any, collections::HashMap, fs, rc::Rc};
 
     #[test]
     fn execute_print_hint() {

--- a/src/vm_core.rs
+++ b/src/vm_core.rs
@@ -317,7 +317,7 @@ mod test {
     };
     use num_bigint::{BigInt, Sign};
     use pyo3::{PyObject, Python, ToPyObject};
-    use std::{collections::HashMap, rc::Rc};
+    use std::{any::Any, collections::HashMap, rc::Rc};
 
     #[test]
     fn execute_print_hint() {
@@ -1200,6 +1200,26 @@ lista_b = [lista_a[k] for k in range(2)]";
         );
         assert!(exec_scopes.data[0].is_empty());
         assert!(hint_locals.is_empty())
+    }
+
+    #[test]
+    fn should_run_py_hint_nonsense_data_should_fail() {
+        let vm = PyVM::new(
+            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+            false,
+            Vec::new(),
+        );
+        let hint_data: Box<dyn Any + 'static> = Box::new("nonsense");
+        let hint_processor = BuiltinHintProcessor::new_empty();
+        assert_eq!(
+            vm.should_run_py_hint(
+                &hint_processor,
+                &mut ExecutionScopes::new(),
+                &hint_data,
+                &HashMap::new(),
+            ),
+            Err(VirtualMachineError::WrongHintData),
+        );
     }
 
     #[test]


### PR DESCRIPTION
This PR:
- adds more unit tests to `cairo_runner.rs`
- removes the warning (_warning: use of deprecated trait `pyo3::PyIterProtocol`: prefer `#[pymethods]` to `#[pyproto]`_) that occurs when compiling them
- moves the declaration of some test Python Objects to a test submodule