### PR TITLE
Modify VmCore::step to return a PyErr

### DIFF
--- a/src/cairo_runner.rs
+++ b/src/cairo_runner.rs
@@ -177,17 +177,15 @@ impl PyCairoRunner {
         let address = Into::<Relocatable>::into(address);
         let constants = self.inner.get_constants().clone();
         while self.pyvm.vm.borrow().get_pc() != &address {
-            self.pyvm
-                .step(
-                    &self.hint_processor,
-                    &mut self.hint_locals,
-                    &mut self.inner.exec_scopes,
-                    &hint_data_dictionary,
-                    Rc::clone(&self.struct_types),
-                    &constants,
-                    self.static_locals.as_ref(),
-                )
-                .map_err(to_py_error)?;
+            self.pyvm.step(
+                &self.hint_processor,
+                &mut self.hint_locals,
+                &mut self.inner.exec_scopes,
+                &hint_data_dictionary,
+                Rc::clone(&self.struct_types),
+                &constants,
+                self.static_locals.as_ref(),
+            )?;
         }
         Ok(())
     }

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -1119,11 +1119,10 @@ memory[fp] = ids.ok_ref
 
             let py_result = py.run(code, Some(globals), None);
 
-            assert!(py_result.unwrap_err().to_string().contains(
-                &VirtualMachineError::NoRegisterInReference
-                    .to_string()
-                    .to_string()
-            ));
+            assert!(py_result
+                .unwrap_err()
+                .to_string()
+                .contains(&VirtualMachineError::NoRegisterInReference.to_string()));
         });
     }
 

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -351,7 +351,7 @@ mod tests {
     use num_bigint::{BigInt, Sign};
     use pyo3::{types::PyDict, PyCell};
 
-    use crate::{memory::PyMemory, relocatable::PyRelocatable, utils::to_vm_error};
+    use crate::{memory::PyMemory, relocatable::PyRelocatable};
 
     use super::*;
 
@@ -434,7 +434,7 @@ memory[fp+2] = ids.CONST
 
             let py_result = py.run(code, Some(globals), None);
 
-            assert_eq!(py_result.map_err(|err| to_vm_error(err, py)), Ok(()));
+            assert!(py_result.is_ok());
             //Check ids.a is now at memory[fp]
             assert_eq!(
                 vm.vm.borrow().get_maybe(&Relocatable::from((1, 0))),
@@ -521,7 +521,7 @@ memory[fp + 2] = ids.SimpleStruct.SIZE
 
             let py_result = py.run(code, Some(globals), None);
 
-            assert_eq!(py_result.map_err(|err| to_vm_error(err, py)), Ok(()));
+            assert!(py_result.is_ok());
             //Check ids.a.x is now at memory[fp]
             assert_eq!(
                 vm.vm.borrow().get_maybe(&Relocatable::from((1, 0))),
@@ -644,7 +644,7 @@ memory[fp + 1] = ids.ns.struct.address_
 
             let py_result = py.run(code, Some(globals), None);
 
-            assert_eq!(py_result.map_err(|err| to_vm_error(err, py)), Ok(()));
+            assert!(py_result.is_ok());
 
             //Check ids.Struct.SIZE is now at memory[fp]
             assert_eq!(
@@ -721,7 +721,7 @@ assert ids.ssp_x_ptr == 5
 
             let py_result = py.run(code, Some(globals), None);
 
-            assert_eq!(py_result.map_err(|err| to_vm_error(err, py)), Ok(()));
+            assert!(py_result.is_ok());
         });
     }
 
@@ -762,10 +762,10 @@ assert ids.ssp_x_ptr == 5
 
             let py_result = py.run(code, Some(globals), None);
 
-            assert_eq!(
-                py_result.map_err(|err| to_vm_error(err, py)),
-                Err(to_vm_error(PyValueError::new_err(IDS_GET_ERROR_MSG), py))
-            );
+            assert!(py_result
+                .unwrap_err()
+                .to_string()
+                .contains(IDS_GET_ERROR_MSG));
         });
     }
 
@@ -822,7 +822,7 @@ assert ids.ssp_x_ptr == 5
 
             let py_result = py.run(code, Some(globals), None);
 
-            assert_eq!(py_result.map_err(|err| to_vm_error(err, py)), Ok(()));
+            assert!(py_result.is_ok());
             //Check ids.a now contains memory[fp]
             assert_eq!(
                 vm.vm.borrow().get_maybe(&Relocatable::from((1, 1))),
@@ -834,10 +834,10 @@ assert ids.ssp_x_ptr == 5
 
             let py_result = py.run(code, Some(globals), None);
 
-            assert_eq!(
-                py_result.map_err(|err| to_vm_error(err, py)),
-                Err(to_vm_error(PyValueError::new_err(IDS_SET_ERROR_MSG), py))
-            );
+            assert!(py_result
+                .unwrap_err()
+                .to_string()
+                .contains(&PyValueError::new_err(IDS_SET_ERROR_MSG).to_string()));
         });
     }
 
@@ -905,7 +905,7 @@ ids.struct.ptr = ids.fp
 
             let py_result = py.run(code, Some(globals), None);
 
-            assert_eq!(py_result.map_err(|err| to_vm_error(err, py)), Ok(()));
+            assert!(py_result.is_ok());
             //Check ids.struct.x now contains 5
             assert_eq!(
                 vm.vm.borrow().get_maybe(&Relocatable::from((1, 0))),
@@ -1013,7 +1013,7 @@ memory[fp] = ids.ok_ref
 
             let py_result = py.run(code, Some(globals), None);
 
-            assert_eq!(py_result.map_err(|err| to_vm_error(err, py)), Ok(()));
+            assert!(py_result.is_ok());
             //Check ids.a is now at memory[fp]
             assert_eq!(
                 vm.vm.borrow().get_maybe(&Relocatable::from((1, 0))),
@@ -1024,27 +1024,19 @@ memory[fp] = ids.ok_ref
 
             let py_result = py.run(code, Some(globals), None);
 
-            assert_eq!(
-                py_result.map_err(|err| to_vm_error(err, py)),
-                Err(to_vm_error(
-                    PyValueError::new_err(
-                        VirtualMachineError::InvalidTrackingGroup(1, 0).to_string()
-                    ),
-                    py
-                ))
-            );
+            assert!(py_result
+                .unwrap_err()
+                .to_string()
+                .contains(&VirtualMachineError::InvalidTrackingGroup(1, 0).to_string()));
 
             let code = r"ids.none_ref";
 
             let py_result = py.run(code, Some(globals), None);
 
-            assert_eq!(
-                py_result.map_err(|err| to_vm_error(err, py)),
-                Err(to_vm_error(
-                    PyValueError::new_err(VirtualMachineError::NoneApTrackingData.to_string()),
-                    py
-                ))
-            );
+            assert!(py_result.unwrap_err().to_string().contains(
+                &PyValueError::new_err(VirtualMachineError::NoneApTrackingData.to_string())
+                    .to_string()
+            ));
         });
     }
 
@@ -1116,7 +1108,7 @@ memory[fp] = ids.ok_ref
 
             let py_result = py.run(code, Some(globals), None);
 
-            assert_eq!(py_result.map_err(|err| to_vm_error(err, py)), Ok(()));
+            assert!(py_result.is_ok());
             //Check ids.a is now at memory[fp]
             assert_eq!(
                 vm.vm.borrow().get_maybe(&Relocatable::from((1, 0))),
@@ -1127,13 +1119,11 @@ memory[fp] = ids.ok_ref
 
             let py_result = py.run(code, Some(globals), None);
 
-            assert_eq!(
-                py_result.map_err(|err| to_vm_error(err, py)),
-                Err(to_vm_error(
-                    PyValueError::new_err(VirtualMachineError::NoRegisterInReference.to_string()),
-                    py
-                ))
-            );
+            assert!(py_result.unwrap_err().to_string().contains(
+                &VirtualMachineError::NoRegisterInReference
+                    .to_string()
+                    .to_string()
+            ));
         });
     }
 
@@ -1219,7 +1209,7 @@ memory[fp] = ids.inner_imm_ref
 
             let py_result = py.run(code, Some(globals), None);
 
-            assert_eq!(py_result.map_err(|err| to_vm_error(err, py)), Ok(()));
+            assert!(py_result.is_ok());
             //Check ids.inner_imm_ref is now at memory[fp]
             assert_eq!(
                 vm.vm.borrow().get_maybe(&Relocatable::from((1, 5))),

--- a/src/scope_manager.rs
+++ b/src/scope_manager.rs
@@ -1,9 +1,9 @@
 use std::{any::Any, collections::HashMap};
 
-use cairo_rs::{
-    any_box, types::exec_scope::ExecutionScopes, vm::errors::vm_errors::VirtualMachineError,
-};
-use pyo3::{pyclass, pymethods, PyObject};
+use cairo_rs::{any_box, types::exec_scope::ExecutionScopes};
+use pyo3::{pyclass, pymethods, PyErr, PyObject};
+
+use crate::utils::to_py_error;
 
 #[pyclass(unsendable)]
 #[derive(Debug, Clone)]
@@ -18,7 +18,7 @@ impl PyEnterScope {
         }
     }
 
-    pub fn update_scopes(&self, scopes: &mut ExecutionScopes) -> Result<(), VirtualMachineError> {
+    pub fn update_scopes(&self, scopes: &mut ExecutionScopes) -> Result<(), PyErr> {
         for scope_variables in self.new_scopes.iter() {
             let mut new_scope = HashMap::<String, Box<dyn Any>>::new();
             for (name, pyobj) in scope_variables {
@@ -57,9 +57,9 @@ impl PyExitScope {
         PyExitScope { num: 0 }
     }
 
-    pub fn update_scopes(&self, scopes: &mut ExecutionScopes) -> Result<(), VirtualMachineError> {
+    pub fn update_scopes(&self, scopes: &mut ExecutionScopes) -> Result<(), PyErr> {
         for _ in 0..self.num {
-            scopes.exit_scope()?
+            scopes.exit_scope().map_err(to_py_error)?
         }
         Ok(())
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,5 @@
-use cairo_rs::vm::errors::vm_errors::VirtualMachineError;
 use num_bigint::BigInt;
-use pyo3::{PyErr, Python};
+use pyo3::PyErr;
 use std::{collections::HashMap, fmt::Display};
 
 pyo3::import_exception!(starkware.cairo.lang.vm.vm_exceptions, VmException);
@@ -8,13 +7,8 @@ pyo3::import_exception!(starkware.cairo.lang.vm.vm_exceptions, VmException);
 #[macro_export]
 macro_rules! pycell {
     ($py:expr, $val:expr) => {
-        PyCell::new($py, $val).map_err(|err| to_vm_error(err, $py))?
+        PyCell::new($py, $val)?
     };
-}
-
-pub fn to_vm_error(pyerror: PyErr, py: Python) -> VirtualMachineError {
-    let value = pyerror.value(py);
-    VirtualMachineError::CustomHint(format!("{:?}", value))
 }
 
 pub fn to_py_error<T: Display>(error: T) -> PyErr {

--- a/src/vm_core.rs
+++ b/src/vm_core.rs
@@ -25,7 +25,6 @@ use pyo3::{PyCell, PyErr};
 use std::any::Any;
 use std::collections::HashMap;
 use std::{cell::RefCell, rc::Rc};
-pyo3::import_exception!(starkware.cairo.lang.vm.vm_exceptions, VmException);
 
 const GLOBAL_NAMES: [&str; 18] = [
     "memory",
@@ -290,7 +289,6 @@ mod test {
             exec_scope::ExecutionScopes,
             relocatable::{MaybeRelocatable, Relocatable},
         },
-        vm::errors::{exec_scope_errors::ExecScopeError, vm_errors::VirtualMachineError},
     };
     use num_bigint::{BigInt, Sign};
     use pyo3::{PyObject, Python, ToPyObject};
@@ -305,17 +303,16 @@ mod test {
         );
         let code = "print(ap)";
         let hint_data = HintProcessorData::new_default(code.to_string(), HashMap::new());
-        assert_eq!(
-            vm.execute_hint(
+        assert!(vm
+            .execute_hint(
                 &hint_data,
                 &mut HashMap::new(),
                 &mut ExecutionScopes::new(),
                 &HashMap::new(),
                 Rc::new(HashMap::new()),
                 None,
-            ),
-            Ok(())
-        );
+            )
+            .is_ok());
     }
 
     #[test]
@@ -327,17 +324,16 @@ mod test {
         );
         let code = "print(ap)";
         let hint_data = HintProcessorData::new_default(code.to_string(), HashMap::new());
-        assert_eq!(
-            vm.execute_hint(
+        assert!(vm
+            .execute_hint(
                 &hint_data,
                 &mut HashMap::new(),
                 &mut ExecutionScopes::new(),
                 &HashMap::new(),
                 Rc::new(HashMap::new()),
                 None,
-            ),
-            Ok(())
-        );
+            )
+            .is_ok());
     }
 
     #[test]
@@ -363,17 +359,16 @@ mod test {
             .unwrap();
         let code = "ids.a = ids.b";
         let hint_data = HintProcessorData::new_default(code.to_string(), references);
-        assert_eq!(
-            vm.execute_hint(
+        assert!(vm
+            .execute_hint(
                 &hint_data,
                 &mut HashMap::new(),
                 &mut ExecutionScopes::new(),
                 &HashMap::new(),
                 Rc::new(HashMap::new()),
                 None,
-            ),
-            Ok(())
-        );
+            )
+            .is_ok());
         assert_eq!(
             vm.vm.borrow().get_maybe(&Relocatable::from((1, 2))),
             Ok(Some(MaybeRelocatable::from(bigint!(2))))
@@ -395,32 +390,30 @@ mod test {
         let code_1 = "assert(ids.CONST != 2)";
         let hint_data = HintProcessorData::new_default(code_1.to_string(), HashMap::new());
 
-        assert_eq!(
-            vm.execute_hint(
+        assert!(vm
+            .execute_hint(
                 &hint_data,
                 &mut HashMap::new(),
                 &mut exec_scopes,
                 &constants,
                 Rc::new(HashMap::new()),
                 None,
-            ),
-            Ok(())
-        );
+            )
+            .is_ok());
 
         let code_2 = "assert(ids.CONST == 1)";
         let hint_data = HintProcessorData::new_default(code_2.to_string(), HashMap::new());
 
-        assert_eq!(
-            vm.execute_hint(
+        assert!(vm
+            .execute_hint(
                 &hint_data,
                 &mut HashMap::new(),
                 &mut exec_scopes,
                 &constants,
                 Rc::new(HashMap::new()),
                 None,
-            ),
-            Ok(())
-        );
+            )
+            .is_ok());
     }
 
     #[test]
@@ -455,8 +448,8 @@ mod test {
             .insert_value(&Relocatable::from((1, 1)), &Relocatable::from((3, 0)))
             .unwrap();
 
-        assert_eq!(
-            vm.step(
+        assert!(vm
+            .step(
                 &hint_processor,
                 &mut HashMap::new(),
                 &mut ExecutionScopes::new(),
@@ -464,9 +457,8 @@ mod test {
                 Rc::new(HashMap::new()),
                 &HashMap::new(),
                 None,
-            ),
-            Ok(())
-        );
+            )
+            .is_ok());
     }
 
     #[test]
@@ -506,8 +498,8 @@ mod test {
         let mut hint_data = HashMap::new();
         hint_data.insert(0, hint_proc_data);
 
-        assert_eq!(
-            vm.step(
+        assert!(vm
+            .step(
                 &hint_processor,
                 &mut HashMap::new(),
                 &mut ExecutionScopes::new(),
@@ -515,9 +507,8 @@ mod test {
                 Rc::new(HashMap::new()),
                 &HashMap::new(),
                 None,
-            ),
-            Ok(())
-        );
+            )
+            .is_ok());
     }
 
     #[test]
@@ -536,29 +527,27 @@ mod test {
         let code_b = "assert(num == 6)";
         let hint_data = HintProcessorData::new_default(code_a.to_string(), HashMap::new());
 
-        assert_eq!(
-            vm.execute_hint(
+        assert!(vm
+            .execute_hint(
                 &hint_data,
                 &mut HashMap::new(),
                 &mut exec_scopes,
                 &HashMap::new(),
                 Rc::new(HashMap::new()),
                 None,
-            ),
-            Ok(())
-        );
+            )
+            .is_ok());
         let hint_data = HintProcessorData::new_default(code_b.to_string(), HashMap::new());
-        assert_eq!(
-            vm.execute_hint(
+        assert!(vm
+            .execute_hint(
                 &hint_data,
                 &mut HashMap::new(),
                 &mut exec_scopes,
                 &HashMap::new(),
                 Rc::new(HashMap::new()),
                 None,
-            ),
-            Ok(())
-        );
+            )
+            .is_ok());
     }
 
     #[test]
@@ -578,53 +567,49 @@ mod test {
         let code_c = "num = num + 3";
         let code_d = "assert(num == 9)";
         let hint_data = HintProcessorData::new_default(code_a.to_string(), HashMap::new());
-        assert_eq!(
-            vm.execute_hint(
+        assert!(vm
+            .execute_hint(
                 &hint_data,
                 &mut HashMap::new(),
                 &mut exec_scopes,
                 &HashMap::new(),
                 Rc::new(HashMap::new()),
                 None,
-            ),
-            Ok(())
-        );
+            )
+            .is_ok());
         let hint_data = HintProcessorData::new_default(code_b.to_string(), HashMap::new());
-        assert_eq!(
-            vm.execute_hint(
+        assert!(vm
+            .execute_hint(
                 &hint_data,
                 &mut HashMap::new(),
                 &mut exec_scopes,
                 &HashMap::new(),
                 Rc::new(HashMap::new()),
                 None,
-            ),
-            Ok(())
-        );
+            )
+            .is_ok());
         let hint_data = HintProcessorData::new_default(code_c.to_string(), HashMap::new());
-        assert_eq!(
-            vm.execute_hint(
+        assert!(vm
+            .execute_hint(
                 &hint_data,
                 &mut HashMap::new(),
                 &mut exec_scopes,
                 &HashMap::new(),
                 Rc::new(HashMap::new()),
                 None,
-            ),
-            Ok(())
-        );
+            )
+            .is_ok());
         let hint_data = HintProcessorData::new_default(code_d.to_string(), HashMap::new());
-        assert_eq!(
-            vm.execute_hint(
+        assert!(vm
+            .execute_hint(
                 &hint_data,
                 &mut HashMap::new(),
                 &mut exec_scopes,
                 &HashMap::new(),
                 Rc::new(HashMap::new()),
                 None,
-            ),
-            Ok(())
-        );
+            )
+            .is_ok());
     }
 
     #[test]
@@ -639,17 +624,16 @@ print(word)";
         let hint_data = HintProcessorData::new_default(code.to_string(), HashMap::new());
         let word = Python::with_gil(|py| -> PyObject { "fruity".to_string().to_object(py) });
         let mut hint_locals = HashMap::from([("word".to_string(), word)]);
-        assert_eq!(
-            vm.execute_hint(
+        assert!(vm
+            .execute_hint(
                 &hint_data,
                 &mut hint_locals,
                 &mut ExecutionScopes::new(),
                 &HashMap::new(),
                 Rc::new(HashMap::new()),
                 None,
-            ),
-            Ok(())
-        );
+            )
+            .is_ok());
         let word_res = Python::with_gil(|py| -> String {
             hint_locals
                 .get("word")
@@ -670,19 +654,15 @@ print(word)";
         let mut exec_scopes = ExecutionScopes::new();
         let code = "vm_exit_scope()";
         let hint_data = HintProcessorData::new_default(code.to_string(), HashMap::new());
-        assert_eq!(
-            vm.execute_hint(
-                &hint_data,
-                &mut HashMap::new(),
-                &mut exec_scopes,
-                &HashMap::new(),
-                Rc::new(HashMap::new()),
-                None,
-            ),
-            Err(VirtualMachineError::MainScopeError(
-                ExecScopeError::ExitMainScopeError
-            ))
+        let x = vm.execute_hint(
+            &hint_data,
+            &mut HashMap::new(),
+            &mut exec_scopes,
+            &HashMap::new(),
+            Rc::new(HashMap::new()),
+            None,
         );
+        assert!(x.is_err());
     }
 
     #[test]
@@ -695,17 +675,16 @@ print(word)";
         let mut exec_scopes = ExecutionScopes::new();
         let code = "vm_enter_scope()";
         let hint_data = HintProcessorData::new_default(code.to_string(), HashMap::new());
-        assert_eq!(
-            vm.execute_hint(
+        assert!(vm
+            .execute_hint(
                 &hint_data,
                 &mut HashMap::new(),
                 &mut exec_scopes,
                 &HashMap::new(),
                 Rc::new(HashMap::new()),
                 None,
-            ),
-            Ok(())
-        );
+            )
+            .is_ok());
         assert_eq!(exec_scopes.data.len(), 2)
     }
 
@@ -720,17 +699,16 @@ print(word)";
         let code = "vm_enter_scope()
 vm_exit_scope()";
         let hint_data = HintProcessorData::new_default(code.to_string(), HashMap::new());
-        assert_eq!(
-            vm.execute_hint(
+        assert!(vm
+            .execute_hint(
                 &hint_data,
                 &mut HashMap::new(),
                 &mut exec_scopes,
                 &HashMap::new(),
                 Rc::new(HashMap::new()),
                 None,
-            ),
-            Ok(())
-        );
+            )
+            .is_ok());
         assert_eq!(exec_scopes.data.len(), 1);
     }
 
@@ -745,30 +723,28 @@ vm_exit_scope()";
         let code_a = "vm_enter_scope()";
         let code_b = "vm_exit_scope()";
         let hint_data = HintProcessorData::new_default(code_a.to_string(), HashMap::new());
-        assert_eq!(
-            vm.execute_hint(
+        assert!(vm
+            .execute_hint(
                 &hint_data,
                 &mut HashMap::new(),
                 &mut exec_scopes,
                 &HashMap::new(),
                 Rc::new(HashMap::new()),
                 None,
-            ),
-            Ok(())
-        );
+            )
+            .is_ok());
         assert_eq!(exec_scopes.data.len(), 2);
         let hint_data = HintProcessorData::new_default(code_b.to_string(), HashMap::new());
-        assert_eq!(
-            vm.execute_hint(
+        assert!(vm
+            .execute_hint(
                 &hint_data,
                 &mut HashMap::new(),
                 &mut exec_scopes,
                 &HashMap::new(),
                 Rc::new(HashMap::new()),
                 None,
-            ),
-            Ok(())
-        );
+            )
+            .is_ok());
         assert_eq!(exec_scopes.data.len(), 1)
     }
 
@@ -784,17 +760,16 @@ vm_exit_scope()";
 vm_exit_scope()
 vm_enter_scope()";
         let hint_data = HintProcessorData::new_default(code.to_string(), HashMap::new());
-        assert_eq!(
-            vm.execute_hint(
+        assert!(vm
+            .execute_hint(
                 &hint_data,
                 &mut HashMap::new(),
                 &mut exec_scopes,
                 &HashMap::new(),
                 Rc::new(HashMap::new()),
                 None,
-            ),
-            Ok(())
-        );
+            )
+            .is_ok());
         assert_eq!(exec_scopes.data.len(), 2)
     }
 
@@ -809,17 +784,16 @@ vm_enter_scope()";
         let code = "lista_a = [1,2,3]
 lista_b = [lista_a[k] for k in range(2)]";
         let hint_data = HintProcessorData::new_default(code.to_string(), HashMap::new());
-        assert_eq!(
-            vm.execute_hint(
+        assert!(vm
+            .execute_hint(
                 &hint_data,
                 &mut HashMap::new(),
                 &mut exec_scopes,
                 &HashMap::new(),
                 Rc::new(HashMap::new()),
                 None,
-            ),
-            Ok(())
-        );
+            )
+            .is_ok());
     }
 
     #[test]
@@ -833,29 +807,27 @@ lista_b = [lista_a[k] for k in range(2)]";
         let code_a = "vm_enter_scope({'n': 12})";
         let code_b = "assert(n == 12)";
         let hint_data = HintProcessorData::new_default(code_a.to_string(), HashMap::new());
-        assert_eq!(
-            vm.execute_hint(
+        assert!(vm
+            .execute_hint(
                 &hint_data,
                 &mut HashMap::new(),
                 &mut exec_scopes,
                 &HashMap::new(),
                 Rc::new(HashMap::new()),
                 None,
-            ),
-            Ok(())
-        );
+            )
+            .is_ok());
         let hint_data = HintProcessorData::new_default(code_b.to_string(), HashMap::new());
-        assert_eq!(
-            vm.execute_hint(
+        assert!(vm
+            .execute_hint(
                 &hint_data,
                 &mut HashMap::new(),
                 &mut exec_scopes,
                 &HashMap::new(),
                 Rc::new(HashMap::new()),
                 None,
-            ),
-            Ok(())
-        );
+            )
+            .is_ok());
         assert_eq!(exec_scopes.data.len(), 2);
         assert!(exec_scopes.data[0].is_empty());
     }
@@ -870,17 +842,16 @@ lista_b = [lista_a[k] for k in range(2)]";
         let mut exec_scopes = ExecutionScopes::new();
         let code = "assert(ap.segment_index == 1)";
         let hint_data = HintProcessorData::new_default(code.to_string(), HashMap::new());
-        assert_eq!(
-            vm.execute_hint(
+        assert!(vm
+            .execute_hint(
                 &hint_data,
                 &mut HashMap::new(),
                 &mut exec_scopes,
                 &HashMap::new(),
                 Rc::new(HashMap::new()),
                 None,
-            ),
-            Ok(())
-        );
+            )
+            .is_ok());
     }
 
     #[test]
@@ -893,17 +864,16 @@ lista_b = [lista_a[k] for k in range(2)]";
         let mut exec_scopes = ExecutionScopes::new();
         let code = "felt = to_felt_or_relocatable(456)";
         let hint_data = HintProcessorData::new_default(code.to_string(), HashMap::new());
-        assert_eq!(
-            vm.execute_hint(
+        assert!(vm
+            .execute_hint(
                 &hint_data,
                 &mut HashMap::new(),
                 &mut exec_scopes,
                 &HashMap::new(),
                 Rc::new(HashMap::new()),
                 None,
-            ),
-            Ok(())
-        );
+            )
+            .is_ok());
         Python::with_gil(|py| {
             assert_eq!(
                 exec_scopes
@@ -961,17 +931,16 @@ lista_b = [lista_a[k] for k in range(2)]";
             ("test_value".to_string(), HintReference::new_simple(1)),
         ]);
         let hint_data = HintProcessorData::new_default(code.to_string(), ids);
-        assert_eq!(
-            vm.execute_hint(
+        assert!(vm
+            .execute_hint(
                 &hint_data,
                 &mut HashMap::new(),
                 &mut exec_scopes,
                 &HashMap::new(),
                 Rc::new(HashMap::new()),
                 None,
-            ),
-            Ok(())
-        );
+            )
+            .is_ok());
         //Check the value of ids.test_value
         assert_eq!(
             vm.vm
@@ -1020,17 +989,16 @@ lista_b = [lista_a[k] for k in range(2)]";
             .unwrap();
 
         let hint_data = HintProcessorData::new_default(code.to_string(), ids);
-        assert_eq!(
-            pyvm.execute_hint(
+        assert!(pyvm
+            .execute_hint(
                 &hint_data,
                 &mut HashMap::new(),
                 &mut exec_scopes,
                 &HashMap::new(),
                 Rc::new(HashMap::new()),
                 None,
-            ),
-            Ok(())
-        )
+            )
+            .is_ok())
     }
 
     #[test]
@@ -1064,22 +1032,21 @@ lista_b = [lista_a[k] for k in range(2)]";
             .unwrap();
 
         let hint_data = HintProcessorData::new_default(code.to_string(), ids);
-        assert_eq!(
-            pyvm.execute_hint(
+        assert!(pyvm
+            .execute_hint(
                 &hint_data,
                 &mut HashMap::new(),
                 &mut ExecutionScopes::new(),
                 &HashMap::new(),
                 Rc::new(HashMap::new()),
                 None,
-            ),
-            Ok(())
-        )
+            )
+            .is_ok())
     }
 
     #[test]
     fn run_hint_with_static_locals() {
-        let mut vm = PyVM::new(
+        let vm = PyVM::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             false,
             Vec::new(),
@@ -1091,17 +1058,16 @@ lista_b = [lista_a[k] for k in range(2)]";
         let code = "number = __number_max";
         let hint_data = HintProcessorData::new_default(code.to_string(), HashMap::new());
         let mut exec_scopes = ExecutionScopes::new();
-        assert_eq!(
-            vm.execute_hint(
+        assert!(vm
+            .execute_hint(
                 &hint_data,
                 &mut HashMap::new(),
                 &mut exec_scopes,
                 &HashMap::new(),
                 Rc::new(HashMap::new()),
                 Some(&static_locals),
-            ),
-            Ok(())
-        );
+            )
+            .is_ok());
         let number = Python::with_gil(|py| -> usize {
             exec_scopes.data[0]
                 .get("number")
@@ -1116,7 +1082,7 @@ lista_b = [lista_a[k] for k in range(2)]";
 
     #[test]
     fn run_hint_with_static_locals_shouldnt_change_its_value() {
-        let mut vm = PyVM::new(
+        let vm = PyVM::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             false,
             Vec::new(),
@@ -1128,17 +1094,16 @@ lista_b = [lista_a[k] for k in range(2)]";
         let code = "__number_max = 15";
         let hint_data = HintProcessorData::new_default(code.to_string(), HashMap::new());
         let mut exec_scopes = ExecutionScopes::new();
-        assert_eq!(
-            vm.execute_hint(
+        assert!(vm
+            .execute_hint(
                 &hint_data,
                 &mut HashMap::new(),
                 &mut exec_scopes,
                 &HashMap::new(),
                 Rc::new(HashMap::new()),
                 Some(&static_locals),
-            ),
-            Ok(())
-        );
+            )
+            .is_ok());
         let number = Python::with_gil(|py| -> usize {
             static_locals
                 .get("__number_max")
@@ -1151,7 +1116,7 @@ lista_b = [lista_a[k] for k in range(2)]";
 
     #[test]
     fn run_hint_with_static_locals_shouldnt_affect_scope_or_hint_locals() {
-        let mut vm = PyVM::new(
+        let vm = PyVM::new(
             BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
             false,
             Vec::new(),
@@ -1164,17 +1129,16 @@ lista_b = [lista_a[k] for k in range(2)]";
         let hint_data = HintProcessorData::new_default(code.to_string(), HashMap::new());
         let mut exec_scopes = ExecutionScopes::new();
         let mut hint_locals = HashMap::new();
-        assert_eq!(
-            vm.execute_hint(
+        assert!(vm
+            .execute_hint(
                 &hint_data,
                 &mut hint_locals,
                 &mut exec_scopes,
                 &HashMap::new(),
                 Rc::new(HashMap::new()),
                 Some(&static_locals),
-            ),
-            Ok(())
-        );
+            )
+            .is_ok());
         assert!(exec_scopes.data[0].is_empty());
         assert!(hint_locals.is_empty())
     }


### PR DESCRIPTION
* Modify VmCore::step to return a PyErr instead of a VirtualMachineError
* Remove unused fn Utils::to_vm_error
