### PR TITLE
Update to new version of cairo-lang

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ make full-test
 ## Script to try out `cairo-rs-py`
 
 The `build_envs.sh` script will build two Python virtual environments:
-- `cairo-lang` containing a pristine install of `cairo-lang==0.10.1`;
-- `cairo-rs-py` containing a patched install of `cairo-lang==0.10.1` that uses `cairo-rs-py` as dependency.
+- `cairo-lang` containing a pristine install of `cairo-lang==0.10.3`;
+- `cairo-rs-py` containing a patched install of `cairo-lang==0.10.3` that uses `cairo-rs-py` as dependency.
 It will also install the required dependencies automatically in Debian-based distributions, CentOs, Fedora and OSX. 
 If you use another OS you can check how to install them manually below.
 

--- a/scripts/build_envs.sh
+++ b/scripts/build_envs.sh
@@ -35,8 +35,8 @@ fi
 SCRIPT_DIR=$(dirname $0)
 
 python3.9 -m venv --upgrade-deps ${SCRIPT_DIR}/cairo-lang ${SCRIPT_DIR}/cairo-rs-py
-${SCRIPT_DIR}/cairo-lang/bin/pip install cairo-lang==0.10.1
-${SCRIPT_DIR}/cairo-rs-py/bin/pip install maturin==0.14.1 cairo-lang==0.10.1
+${SCRIPT_DIR}/cairo-lang/bin/pip install cairo-lang==0.10.3
+${SCRIPT_DIR}/cairo-rs-py/bin/pip install maturin==0.14.1 cairo-lang==0.10.3
 ${SCRIPT_DIR}/cairo-rs-py/bin/maturin build --manifest-path ${SCRIPT_DIR}/../Cargo.toml --release --strip --interpreter 3.9 --no-default-features --features extension
 ${SCRIPT_DIR}/cairo-rs-py/bin/pip install ${SCRIPT_DIR}/../target/wheels/cairo_rs_py-*.whl
 patch --directory ${SCRIPT_DIR}/cairo-rs-py/lib/python3.9/site-packages/ --strip 2 < ${SCRIPT_DIR}/move-to-cairo-rs-py.patch


### PR DESCRIPTION
Upgraded the cairo-lang version to 0.10.3 to match the sequencer address of the tests in the devnet. 