### PR TITLE
Fix `maturin build`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,19 +3,24 @@ name = "cairo-rs-py"
 version = "0.1.0"
 edition = "2021"
 
-[lib]
-name = "cairo_rs_py"
-crate-type = ["cdylib"]
-
-[features]
-extension = ["pyo3/num-bigint", "pyo3/extension-module"]
-default = ["pyo3/num-bigint", "pyo3/auto-initialize"]
-
 [dependencies]
-pyo3 = { version = "0.16.5" }
+pyo3 = { version = "0.16.5", features = ["num-bigint"] }
 cairo-rs = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "c22a11db4e22bf324534c7b6f978a40478f85d50" }
 num-bigint = "0.4"
 lazy_static = "1.4.0"
 
 [dev-dependencies.rusty-hook]
 version = "0.11"
+
+[features]
+extension-module = ["pyo3/extension-module"]
+embedded-python = ["pyo3/auto-initialize"]
+default = ["extension-module"]
+
+[lib]
+name = "cairo_rs_py"
+crate-type = ["cdylib"]
+required-features = ["extension-module"]
+
+[profile.release]
+debug = 1

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ coverage:
 	deactivate
 
 test: $(COMPILED_TESTS) $(COMPILED_BAD_TESTS)
-	cargo test
+	cargo test --no-default-features --features embedded-python
 
 clippy:
 	cargo clippy  -- -D warnings

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ check:
 
 coverage:
 	PYENV_VERSION=pypy3.7-7.3.9 . cairo-rs-py-env/bin/activate && \
-	cargo tarpaulin --out Xml && \
+	cargo tarpaulin --no-default-features --features embedded-python --out Xml && \
 	deactivate
 
 test: $(COMPILED_TESTS) $(COMPILED_BAD_TESTS)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,9 @@ mod to_felt_or_relocatable;
 mod utils;
 mod vm_core;
 
+#[cfg(all(feature = "extension-module", feature = "embedded-python"))]
+compile_error!("\"extension-module\" is incompatible with \"embedded-python\" as it inhibits linking with cpython");
+
 use cairo_runner::PyCairoRunner;
 use pyo3::prelude::*;
 


### PR DESCRIPTION
Building `cairo-rs-py` as library requires __not__ linking to the CPython library. This is achieved by making the default build pass the `extension-module` feature flag to PyO3 and making it exclusive with `auto-initialize`.
When testing we do need this to initialize the CPython machine, so it's a different feature that the `make` target passes to Cargo.