### PR TITLE
Update cairo-rs version to last commit in main (last PR merged: #742)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,7 +132,7 @@ checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 [[package]]
 name = "cairo-felt"
 version = "0.1.0"
-source = "git+https://github.com/lambdaclass/cairo-rs.git?rev=7f8c2fb5ddebfdfe557c79f0072483f550e9e0e3#7f8c2fb5ddebfdfe557c79f0072483f550e9e0e3"
+source = "git+https://github.com/lambdaclass/cairo-rs.git?rev=75bfba3850194a270d270e80ea57d39235690edd#75bfba3850194a270d270e80ea57d39235690edd"
 dependencies = [
  "lazy_static",
  "num-bigint",
@@ -156,7 +156,7 @@ dependencies = [
 [[package]]
 name = "cairo-vm"
 version = "0.1.1"
-source = "git+https://github.com/lambdaclass/cairo-rs.git?rev=7f8c2fb5ddebfdfe557c79f0072483f550e9e0e3#7f8c2fb5ddebfdfe557c79f0072483f550e9e0e3"
+source = "git+https://github.com/lambdaclass/cairo-rs.git?rev=75bfba3850194a270d270e80ea57d39235690edd#75bfba3850194a270d270e80ea57d39235690edd"
 dependencies = [
  "bincode",
  "cairo-felt",
@@ -590,7 +590,7 @@ dependencies = [
 [[package]]
 name = "parse-hyperlinks"
 version = "0.23.4"
-source = "git+https://github.com/lambdaclass/cairo-rs.git?rev=7f8c2fb5ddebfdfe557c79f0072483f550e9e0e3#7f8c2fb5ddebfdfe557c79f0072483f550e9e0e3"
+source = "git+https://github.com/lambdaclass/cairo-rs.git?rev=75bfba3850194a270d270e80ea57d39235690edd#75bfba3850194a270d270e80ea57d39235690edd"
 dependencies = [
  "nom",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,13 +130,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 
 [[package]]
-name = "cairo-rs"
+name = "cairo-felt"
 version = "0.1.0"
-source = "git+https://github.com/lambdaclass/cairo-rs.git?rev=2a687c0795a99ce353d186c305c00feccba73bee#2a687c0795a99ce353d186c305c00feccba73bee"
+source = "git+https://github.com/lambdaclass/cairo-rs.git?rev=9321055390512cd2e668a82fa34619c20baee9d7#9321055390512cd2e668a82fa34619c20baee9d7"
+dependencies = [
+ "lazy_static",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "cairo-rs-py"
+version = "0.1.0"
+dependencies = [
+ "cairo-felt",
+ "cairo-vm",
+ "lazy_static",
+ "num-bigint",
+ "pyo3",
+ "rusty-hook",
+]
+
+[[package]]
+name = "cairo-vm"
+version = "0.1.1"
+source = "git+https://github.com/lambdaclass/cairo-rs.git?rev=9321055390512cd2e668a82fa34619c20baee9d7#9321055390512cd2e668a82fa34619c20baee9d7"
 dependencies = [
  "bincode",
+ "cairo-felt",
  "clap",
- "felt",
  "generic-array",
  "hex",
  "keccak",
@@ -155,18 +179,6 @@ dependencies = [
  "sha3",
  "starknet-crypto",
  "thiserror",
-]
-
-[[package]]
-name = "cairo-rs-py"
-version = "0.1.0"
-dependencies = [
- "cairo-rs",
- "felt",
- "lazy_static",
- "num-bigint",
- "pyo3",
- "rusty-hook",
 ]
 
 [[package]]
@@ -308,18 +320,6 @@ checksum = "a2d328fc287c61314c4a61af7cfdcbd7e678e39778488c7cb13ec133ce0f4059"
 dependencies = [
  "fsio",
  "indexmap",
-]
-
-[[package]]
-name = "felt"
-version = "0.1.0"
-source = "git+https://github.com/lambdaclass/cairo-rs.git?rev=2a687c0795a99ce353d186c305c00feccba73bee#2a687c0795a99ce353d186c305c00feccba73bee"
-dependencies = [
- "lazy_static",
- "num-bigint",
- "num-integer",
- "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -590,7 +590,7 @@ dependencies = [
 [[package]]
 name = "parse-hyperlinks"
 version = "0.23.4"
-source = "git+https://github.com/lambdaclass/cairo-rs.git?rev=2a687c0795a99ce353d186c305c00feccba73bee#2a687c0795a99ce353d186c305c00feccba73bee"
+source = "git+https://github.com/lambdaclass/cairo-rs.git?rev=9321055390512cd2e668a82fa34619c20baee9d7#9321055390512cd2e668a82fa34619c20baee9d7"
 dependencies = [
  "nom",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,7 +132,7 @@ checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 [[package]]
 name = "cairo-felt"
 version = "0.1.0"
-source = "git+https://github.com/lambdaclass/cairo-rs.git?rev=9321055390512cd2e668a82fa34619c20baee9d7#9321055390512cd2e668a82fa34619c20baee9d7"
+source = "git+https://github.com/lambdaclass/cairo-rs.git?rev=7f8c2fb5ddebfdfe557c79f0072483f550e9e0e3#7f8c2fb5ddebfdfe557c79f0072483f550e9e0e3"
 dependencies = [
  "lazy_static",
  "num-bigint",
@@ -156,7 +156,7 @@ dependencies = [
 [[package]]
 name = "cairo-vm"
 version = "0.1.1"
-source = "git+https://github.com/lambdaclass/cairo-rs.git?rev=9321055390512cd2e668a82fa34619c20baee9d7#9321055390512cd2e668a82fa34619c20baee9d7"
+source = "git+https://github.com/lambdaclass/cairo-rs.git?rev=7f8c2fb5ddebfdfe557c79f0072483f550e9e0e3#7f8c2fb5ddebfdfe557c79f0072483f550e9e0e3"
 dependencies = [
  "bincode",
  "cairo-felt",
@@ -590,7 +590,7 @@ dependencies = [
 [[package]]
 name = "parse-hyperlinks"
 version = "0.23.4"
-source = "git+https://github.com/lambdaclass/cairo-rs.git?rev=9321055390512cd2e668a82fa34619c20baee9d7#9321055390512cd2e668a82fa34619c20baee9d7"
+source = "git+https://github.com/lambdaclass/cairo-rs.git?rev=7f8c2fb5ddebfdfe557c79f0072483f550e9e0e3#7f8c2fb5ddebfdfe557c79f0072483f550e9e0e3"
 dependencies = [
  "nom",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,10 +132,11 @@ checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 [[package]]
 name = "cairo-rs"
 version = "0.1.0"
-source = "git+https://github.com/lambdaclass/cairo-rs.git?rev=8e3541768cf8a01b4b8e50e427cef19cae56c9e2#8e3541768cf8a01b4b8e50e427cef19cae56c9e2"
+source = "git+https://github.com/lambdaclass/cairo-rs.git?rev=2a687c0795a99ce353d186c305c00feccba73bee#2a687c0795a99ce353d186c305c00feccba73bee"
 dependencies = [
  "bincode",
  "clap",
+ "felt",
  "generic-array",
  "hex",
  "keccak",
@@ -161,6 +162,7 @@ name = "cairo-rs-py"
 version = "0.1.0"
 dependencies = [
  "cairo-rs",
+ "felt",
  "lazy_static",
  "num-bigint",
  "pyo3",
@@ -306,6 +308,18 @@ checksum = "a2d328fc287c61314c4a61af7cfdcbd7e678e39778488c7cb13ec133ce0f4059"
 dependencies = [
  "fsio",
  "indexmap",
+]
+
+[[package]]
+name = "felt"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/cairo-rs.git?rev=2a687c0795a99ce353d186c305c00feccba73bee#2a687c0795a99ce353d186c305c00feccba73bee"
+dependencies = [
+ "lazy_static",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -576,7 +590,7 @@ dependencies = [
 [[package]]
 name = "parse-hyperlinks"
 version = "0.23.4"
-source = "git+https://github.com/lambdaclass/cairo-rs.git?rev=8e3541768cf8a01b4b8e50e427cef19cae56c9e2#8e3541768cf8a01b4b8e50e427cef19cae56c9e2"
+source = "git+https://github.com/lambdaclass/cairo-rs.git?rev=2a687c0795a99ce353d186c305c00feccba73bee#2a687c0795a99ce353d186c305c00feccba73bee"
 dependencies = [
  "nom",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 
 [dependencies]
 pyo3 = { version = "0.16.5", features = ["num-bigint"] }
-cairo-rs = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "2a687c0795a99ce353d186c305c00feccba73bee" }
-felt = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "2a687c0795a99ce353d186c305c00feccba73bee" }
+cairo-vm = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "9321055390512cd2e668a82fa34619c20baee9d7" }
+cairo-felt = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "9321055390512cd2e668a82fa34619c20baee9d7" }
 num-bigint = "0.4"
 lazy_static = "1.4.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 
 [dependencies]
 pyo3 = { version = "0.16.5", features = ["num-bigint"] }
-cairo-vm = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "9321055390512cd2e668a82fa34619c20baee9d7" }
-cairo-felt = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "9321055390512cd2e668a82fa34619c20baee9d7" }
+cairo-vm = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "7f8c2fb5ddebfdfe557c79f0072483f550e9e0e3" }
+cairo-felt = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "7f8c2fb5ddebfdfe557c79f0072483f550e9e0e3" }
 num-bigint = "0.4"
 lazy_static = "1.4.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,8 @@ edition = "2021"
 
 [dependencies]
 pyo3 = { version = "0.16.5", features = ["num-bigint"] }
-cairo-rs = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "8e3541768cf8a01b4b8e50e427cef19cae56c9e2" }
+cairo-rs = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "2a687c0795a99ce353d186c305c00feccba73bee" }
+felt = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "2a687c0795a99ce353d186c305c00feccba73bee" }
 num-bigint = "0.4"
 lazy_static = "1.4.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 
 [dependencies]
 pyo3 = { version = "0.16.5", features = ["num-bigint"] }
-cairo-vm = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "7f8c2fb5ddebfdfe557c79f0072483f550e9e0e3" }
-cairo-felt = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "7f8c2fb5ddebfdfe557c79f0072483f550e9e0e3" }
+cairo-vm = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "75bfba3850194a270d270e80ea57d39235690edd" }
+cairo-felt = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "75bfba3850194a270d270e80ea57d39235690edd" }
 num-bigint = "0.4"
 lazy_static = "1.4.0"
 

--- a/src/cairo_runner.rs
+++ b/src/cairo_runner.rs
@@ -723,9 +723,7 @@ mod test {
         impl MyIterator {
             #[getter]
             pub fn __annotations__(&self) -> PyResult<Annotations> {
-                Ok(Annotations {
-                    0: self.types.clone(),
-                })
+                Ok(Annotations(self.types.clone()))
             }
             pub fn __iter__(slf: PyRef<Self>) -> PyRef<Self> {
                 slf
@@ -763,7 +761,7 @@ mod test {
         #[pymethods]
         impl TypeFelt {
             fn __repr__(&self) -> String {
-                format!("TypeFelt")
+                "TypeFelt".to_string()
             }
         }
 
@@ -775,7 +773,7 @@ mod test {
         #[pymethods]
         impl TypePointer {
             fn __repr__(&self) -> String {
-                format!("TypePointer")
+                "TypePointer".to_string()
             }
         }
 
@@ -787,7 +785,7 @@ mod test {
         #[pymethods]
         impl TypeStruct {
             fn __repr__(&self) -> String {
-                format!("TypeStruct")
+                "TypeStruct".to_string()
             }
         }
     }
@@ -1421,7 +1419,7 @@ mod test {
         runner
             .initialize_function_runner()
             .expect("Failed to initialize function runner");
-        let pc_before_run = runner.pyvm.vm.borrow().get_pc().clone();
+        let pc_before_run = *runner.pyvm.vm.borrow().get_pc();
 
         Python::with_gil(|py| {
             let result = runner.run_from_entrypoint(
@@ -1439,7 +1437,7 @@ mod test {
             assert!(format!("{:?}", result).contains("Execution reached the end of the program."));
         });
 
-        let pc_after_run = runner.pyvm.vm.borrow().get_pc().clone();
+        let pc_after_run = *runner.pyvm.vm.borrow().get_pc();
 
         // As the run_resurces provide 0 steps, no steps should have been run
         // To check this, we check that the pc hasnt changed after "running" the vm
@@ -1888,8 +1886,7 @@ mod test {
                 .unwrap()
                 .unwrap()
                 .get_relocatable()
-                .unwrap()
-                .clone();
+                .unwrap();
 
             assert_eq!(
                 vm_ref
@@ -1916,8 +1913,7 @@ mod test {
                 .unwrap()
                 .unwrap()
                 .get_relocatable()
-                .unwrap()
-                .clone();
+                .unwrap();
 
             assert_eq!(
                 vm_ref

--- a/src/cairo_runner.rs
+++ b/src/cairo_runner.rs
@@ -686,10 +686,10 @@ impl PyExecutionResources {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::bigint;
+    use crate::biguint;
     use crate::relocatable::PyMaybeRelocatable::RelocatableValue;
     use cairo_felt::{Felt, NewFelt};
-    use num_bigint::BigInt;
+    use num_bigint::BigUint;
     use std::env::temp_dir;
     use std::fs;
 
@@ -1301,8 +1301,8 @@ mod test {
             let args = MyIterator {
                 iter: Box::new(
                     vec![
-                        PyMaybeRelocatable::from(bigint!(0)).to_object(py),
-                        PyMaybeRelocatable::from(bigint!(2)).to_object(py),
+                        PyMaybeRelocatable::from(biguint!(0_u32)).to_object(py),
+                        PyMaybeRelocatable::from(biguint!(2_u32)).to_object(py),
                     ]
                     .into_iter(),
                 ),
@@ -1589,7 +1589,7 @@ mod test {
 
             let args = MyIterator {
                 iter: Box::new(
-                    vec![PyMaybeRelocatable::from(bigint!(value)).to_object(*py)].into_iter(),
+                    vec![PyMaybeRelocatable::from(biguint!(value)).to_object(*py)].into_iter(),
                 ),
                 types: vec![PyType::TypeFelt],
             };
@@ -1630,12 +1630,12 @@ mod test {
 
         Python::with_gil(|py| {
             let array = vec![
-                PyMaybeRelocatable::from(bigint!(1)).to_object(py),
-                PyMaybeRelocatable::from(bigint!(2)).to_object(py),
-                PyMaybeRelocatable::from(bigint!(4)).to_object(py),
-                PyMaybeRelocatable::from(bigint!(8)).to_object(py),
+                PyMaybeRelocatable::from(biguint!(1_u32)).to_object(py),
+                PyMaybeRelocatable::from(biguint!(2_u32)).to_object(py),
+                PyMaybeRelocatable::from(biguint!(4_u32)).to_object(py),
+                PyMaybeRelocatable::from(biguint!(8_u32)).to_object(py),
             ];
-            let size = PyMaybeRelocatable::from(bigint!(array.len()));
+            let size = PyMaybeRelocatable::from(biguint!(array.len()));
             let args = vec![array.into_py(py), size.to_object(py)];
             let result = runner.run_from_entrypoint(
                 py,
@@ -1671,13 +1671,13 @@ mod test {
 
         (*runner.pyvm.get_vm()).borrow_mut().add_memory_segment();
         runner
-            .insert(&(0, 0).into(), PyMaybeRelocatable::Int(bigint!(3)))
+            .insert(&(0, 0).into(), PyMaybeRelocatable::Int(biguint!(3_u32)))
             .unwrap();
         runner
-            .insert(&(0, 1).into(), PyMaybeRelocatable::Int(bigint!(4)))
+            .insert(&(0, 1).into(), PyMaybeRelocatable::Int(biguint!(4_u32)))
             .unwrap();
         runner
-            .insert(&(0, 2).into(), PyMaybeRelocatable::Int(bigint!(5)))
+            .insert(&(0, 2).into(), PyMaybeRelocatable::Int(biguint!(5_u32)))
             .unwrap();
         assert_eq!(
             (*runner.pyvm.get_vm())
@@ -1696,13 +1696,13 @@ mod test {
 
         (*runner.pyvm.get_vm()).borrow_mut().add_memory_segment();
         runner
-            .insert(&(0, 0).into(), PyMaybeRelocatable::Int(bigint!(3)))
+            .insert(&(0, 0).into(), PyMaybeRelocatable::Int(biguint!(3_u32)))
             .unwrap();
         runner
-            .insert(&(0, 1).into(), PyMaybeRelocatable::Int(bigint!(4)))
+            .insert(&(0, 1).into(), PyMaybeRelocatable::Int(biguint!(4_u32)))
             .unwrap();
         runner
-            .insert(&(0, 0).into(), PyMaybeRelocatable::Int(bigint!(5)))
+            .insert(&(0, 0).into(), PyMaybeRelocatable::Int(biguint!(5_u32)))
             .expect_err("insertion succeeded when it should've failed");
         assert_eq!(
             (*runner.pyvm.get_vm())
@@ -2135,8 +2135,8 @@ mod test {
             let arg = MyIterator {
                 iter: Box::new(
                     vec![
-                        PyMaybeRelocatable::from(bigint!(0)).to_object(py),
-                        PyMaybeRelocatable::from(bigint!(2)).to_object(py),
+                        PyMaybeRelocatable::from(biguint!(0_u32)).to_object(py),
+                        PyMaybeRelocatable::from(biguint!(2_u32)).to_object(py),
                     ]
                     .into_iter(),
                 ),
@@ -2149,8 +2149,8 @@ mod test {
             assert_eq!(
                 stack,
                 vec![
-                    PyMaybeRelocatable::from(bigint!(0)),
-                    PyMaybeRelocatable::from(bigint!(2)),
+                    PyMaybeRelocatable::from(biguint!(0_u32)),
+                    PyMaybeRelocatable::from(biguint!(2_u32)),
                 ]
             );
         })
@@ -2211,14 +2211,14 @@ mod test {
                 runner
                     .get(py, &addr)
                     .expect("Could not get value")
-                    .map(|x| x.extract::<BigInt>(py))
+                    .map(|x| x.extract::<BigUint>(py))
                     .transpose()
-                    .expect("Could not convert value to a BigInt")
+                    .expect("Could not convert value to a biguint")
             };
-            assert_eq!(get_value(&segment, 0), Some(bigint!(1)));
-            assert_eq!(get_value(&segment, 1), Some(bigint!(2)));
-            assert_eq!(get_value(&segment, 2), Some(bigint!(3)));
-            assert_eq!(get_value(&segment, 3), Some(bigint!(4)));
+            assert_eq!(get_value(&segment, 0), Some(biguint!(1_u32)));
+            assert_eq!(get_value(&segment, 1), Some(biguint!(2_u32)));
+            assert_eq!(get_value(&segment, 2), Some(biguint!(3_u32)));
+            assert_eq!(get_value(&segment, 3), Some(biguint!(4_u32)));
             assert_eq!(get_value(&segment, 4), None);
         });
     }
@@ -2298,8 +2298,8 @@ mod test {
             let arg = MyIterator {
                 iter: Box::new(
                     vec![
-                        PyMaybeRelocatable::from(bigint!(0)).to_object(py),
-                        PyMaybeRelocatable::from(bigint!(2)).to_object(py),
+                        PyMaybeRelocatable::from(biguint!(0_u32)).to_object(py),
+                        PyMaybeRelocatable::from(biguint!(2_u32)).to_object(py),
                     ]
                     .into_iter(),
                 ),
@@ -2320,7 +2320,7 @@ mod test {
         Python::with_gil(|py| {
             let segment = runner.add_segment();
 
-            let set_value = |addr: &PyRelocatable, offset, value: BigInt| {
+            let set_value = |addr: &PyRelocatable, offset, value: BigUint| {
                 let addr = addr.__add__(offset);
                 memory
                     .__setitem__(&addr, PyMaybeRelocatable::Int(value))
@@ -2331,20 +2331,20 @@ mod test {
                 memory
                     .__getitem__(&addr, py)
                     .expect("Could not get value from memory.")
-                    .map(|x| x.extract::<BigInt>(py))
+                    .map(|x| x.extract::<BigUint>(py))
                     .transpose()
-                    .expect("Could not convert value to a BigInt")
+                    .expect("Could not convert value to a biguint")
             };
 
-            set_value(&segment, 0, bigint!(1));
-            set_value(&segment, 1, bigint!(2));
-            set_value(&segment, 2, bigint!(3));
-            set_value(&segment, 3, bigint!(4));
+            set_value(&segment, 0, biguint!(1_u32));
+            set_value(&segment, 1, biguint!(2_u32));
+            set_value(&segment, 2, biguint!(3_u32));
+            set_value(&segment, 3, biguint!(4_u32));
 
-            assert_eq!(get_value(&segment, 0), Some(bigint!(1)));
-            assert_eq!(get_value(&segment, 1), Some(bigint!(2)));
-            assert_eq!(get_value(&segment, 2), Some(bigint!(3)));
-            assert_eq!(get_value(&segment, 3), Some(bigint!(4)));
+            assert_eq!(get_value(&segment, 0), Some(biguint!(1_u32)));
+            assert_eq!(get_value(&segment, 1), Some(biguint!(2_u32)));
+            assert_eq!(get_value(&segment, 2), Some(biguint!(3_u32)));
+            assert_eq!(get_value(&segment, 3), Some(biguint!(4_u32)));
             assert_eq!(get_value(&segment, 4), None);
         });
     }
@@ -2368,7 +2368,7 @@ mod test {
         Python::with_gil(|py| {
             let segment = runner.add_segment();
 
-            let set_value = |addr: &PyRelocatable, offset, value: BigInt| {
+            let set_value = |addr: &PyRelocatable, offset, value: BigUint| {
                 let addr = addr.__add__(offset);
                 memory
                     .__setitem__(&addr, PyMaybeRelocatable::Int(value))
@@ -2379,20 +2379,20 @@ mod test {
                 memory
                     .__getitem__(&addr, py)
                     .expect("Could not get value from memory.")
-                    .map(|x| x.extract::<BigInt>(py))
+                    .map(|x| x.extract::<BigUint>(py))
                     .transpose()
-                    .expect("Could not convert value to a BigInt")
+                    .expect("Could not convert value to a biguint")
             };
 
-            set_value(&segment, 0, bigint!(1));
-            set_value(&segment, 1, bigint!(2));
-            set_value(&segment, 2, bigint!(3));
-            set_value(&segment, 3, bigint!(4));
+            set_value(&segment, 0, biguint!(1_u32));
+            set_value(&segment, 1, biguint!(2_u32));
+            set_value(&segment, 2, biguint!(3_u32));
+            set_value(&segment, 3, biguint!(4_u32));
 
-            assert_eq!(get_value(&segment, 0), Some(bigint!(1)));
-            assert_eq!(get_value(&segment, 1), Some(bigint!(2)));
-            assert_eq!(get_value(&segment, 2), Some(bigint!(3)));
-            assert_eq!(get_value(&segment, 3), Some(bigint!(4)));
+            assert_eq!(get_value(&segment, 0), Some(biguint!(1_u32)));
+            assert_eq!(get_value(&segment, 1), Some(biguint!(2_u32)));
+            assert_eq!(get_value(&segment, 2), Some(biguint!(3_u32)));
+            assert_eq!(get_value(&segment, 3), Some(biguint!(4_u32)));
             assert_eq!(get_value(&segment, 4), None);
         });
     }
@@ -2558,8 +2558,8 @@ mod test {
                 PyMaybeRelocatable::Int(value) => Ok(value),
                 PyMaybeRelocatable::RelocatableValue(r) => Err(r),
             };
-            let expected = bigint!(144);
-            assert_eq!(result, Ok(&expected) as Result<&BigInt, &PyRelocatable>);
+            let expected = biguint!(144_u32);
+            assert_eq!(result, Ok(&expected) as Result<&BigUint, &PyRelocatable>);
         });
     }
 

--- a/src/cairo_runner.rs
+++ b/src/cairo_runner.rs
@@ -350,7 +350,7 @@ impl PyCairoRunner {
             .to_object(py))
     }
 
-    #[allow(dead_code, unused)]
+    #[allow(unused)]
     #[allow(clippy::too_many_arguments)]
     pub fn run_from_entrypoint(
         &mut self,

--- a/src/cairo_runner.rs
+++ b/src/cairo_runner.rs
@@ -350,8 +350,8 @@ impl PyCairoRunner {
             .to_object(py))
     }
 
+    #[allow(dead_code, unused)]
     #[allow(clippy::too_many_arguments)]
-    #[allow(clippy::unused_variables)]
     pub fn run_from_entrypoint(
         &mut self,
         py: Python,

--- a/src/cairo_runner.rs
+++ b/src/cairo_runner.rs
@@ -6,7 +6,7 @@ use crate::{
     utils::to_py_error,
     vm_core::PyVM,
 };
-use cairo_rs::{
+use cairo_vm::{
     cairo_run::write_output,
     hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor,
     serde::deserialize_program::Member,
@@ -146,7 +146,7 @@ impl PyCairoRunner {
                 .ok_or(CairoRunError::Trace(TraceError::TraceNotEnabled))
                 .map_err(to_py_error)?;
 
-            match cairo_rs::cairo_run::write_binary_trace(relocated_trace, &trace_path) {
+            match cairo_vm::cairo_run::write_binary_trace(relocated_trace, &trace_path) {
                 Ok(()) => (),
                 Err(_e) => {
                     return Err(CairoRunError::Runner(RunnerError::WriteFail)).map_err(to_py_error)
@@ -156,7 +156,7 @@ impl PyCairoRunner {
 
         if let Some(memory_path) = memory_file {
             let memory_path = PathBuf::from(memory_path);
-            cairo_rs::cairo_run::write_binary_memory(&self.inner.relocated_memory, &memory_path)
+            cairo_vm::cairo_run::write_binary_memory(&self.inner.relocated_memory, &memory_path)
                 .map_err(|_| to_py_error(CairoRunError::Runner(RunnerError::WriteFail)))?;
         }
 
@@ -688,7 +688,7 @@ mod test {
     use super::*;
     use crate::bigint;
     use crate::relocatable::PyMaybeRelocatable::RelocatableValue;
-    use felt::{Felt, NewFelt};
+    use cairo_felt::{Felt, NewFelt};
     use num_bigint::BigInt;
     use std::env::temp_dir;
     use std::fs;

--- a/src/ecdsa.rs
+++ b/src/ecdsa.rs
@@ -1,3 +1,4 @@
+use num_bigint::BigUint;
 use std::collections::HashMap;
 
 use cairo_vm::{
@@ -6,7 +7,6 @@ use cairo_vm::{
 };
 
 use cairo_felt::Felt;
-use num_bigint::BigInt;
 use pyo3::prelude::*;
 
 use crate::relocatable::PyRelocatable;
@@ -26,7 +26,7 @@ impl PySignature {
         }
     }
 
-    pub fn add_signature(&mut self, address: PyRelocatable, pair: (BigInt, BigInt)) {
+    pub fn add_signature(&mut self, address: PyRelocatable, pair: (BigUint, BigUint)) {
         self.signatures
             .insert(address, (pair.0.into(), pair.1.into()));
     }
@@ -61,10 +61,8 @@ impl ToPyObject for PySignature {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::relocatable::PyRelocatable;
-    use num_bigint::{BigInt, Sign};
-
     use crate::cairo_runner::PyCairoRunner;
+    use crate::relocatable::PyRelocatable;
 
     use std::fs;
 
@@ -81,8 +79,8 @@ mod test {
         };
 
         let numbers = (
-            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
-            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+            BigUint::new(vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+            BigUint::new(vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
         );
 
         let mut signature = PySignature::new();
@@ -98,8 +96,8 @@ mod test {
         };
 
         let numbers = (
-            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 13421772]),
-            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 13421772]),
+            BigUint::new(vec![1, 0, 0, 0, 0, 0, 17, 13421772]),
+            BigUint::new(vec![1, 0, 0, 0, 0, 0, 17, 13421772]),
         );
 
         let mut signature = PySignature::new();
@@ -135,8 +133,8 @@ mod test {
         };
 
         let numbers = (
-            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
-            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+            BigUint::new(vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
+            BigUint::new(vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
         );
 
         let mut signature = PySignature::new();

--- a/src/ecdsa.rs
+++ b/src/ecdsa.rs
@@ -5,6 +5,7 @@ use cairo_rs::{
     vm::{errors::vm_errors::VirtualMachineError, runners::builtin_runner::SignatureBuiltinRunner},
 };
 
+use felt::Felt;
 use num_bigint::BigInt;
 use pyo3::prelude::*;
 
@@ -13,7 +14,7 @@ use crate::relocatable::PyRelocatable;
 #[pyclass(name = "Signature")]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PySignature {
-    signatures: HashMap<PyRelocatable, (BigInt, BigInt)>,
+    signatures: HashMap<PyRelocatable, (Felt, Felt)>,
 }
 
 #[pymethods]
@@ -26,7 +27,8 @@ impl PySignature {
     }
 
     pub fn add_signature(&mut self, address: PyRelocatable, pair: (BigInt, BigInt)) {
-        self.signatures.insert(address, pair);
+        self.signatures
+            .insert(address, (pair.0.into(), pair.1.into()));
     }
 }
 

--- a/src/ecdsa.rs
+++ b/src/ecdsa.rs
@@ -1,11 +1,11 @@
 use std::collections::HashMap;
 
-use cairo_rs::{
+use cairo_vm::{
     types::relocatable::Relocatable,
     vm::{errors::vm_errors::VirtualMachineError, runners::builtin_runner::SignatureBuiltinRunner},
 };
 
-use felt::Felt;
+use cairo_felt::Felt;
 use num_bigint::BigInt;
 use pyo3::prelude::*;
 

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -1,6 +1,6 @@
 use crate::utils::const_path_to_const_name;
 use cairo_felt::{Felt, FeltOps};
-use num_bigint::BigInt;
+use num_bigint::BigUint;
 use pyo3::exceptions::PyValueError;
 use std::{
     cell::RefCell,
@@ -34,7 +34,7 @@ pub struct PyIds {
     vm: Rc<RefCell<VirtualMachine>>,
     references: HashMap<String, HintReference>,
     ap_tracking: ApTracking,
-    constants: HashMap<String, BigInt>,
+    constants: HashMap<String, BigUint>,
     struct_types: Rc<HashMap<String, HashMap<String, Member>>>,
 }
 
@@ -245,7 +245,7 @@ pub fn get_value_from_reference(
 ) -> PyResult<PyMaybeRelocatable> {
     // //First handle case on only immediate
     if let OffsetValue::Immediate(num) = &hint_reference.offset1 {
-        return Ok(PyMaybeRelocatable::from(num.to_bigint()));
+        return Ok(PyMaybeRelocatable::from(num.to_biguint()));
     }
     //Then calculate address
     let var_addr = compute_addr_from_reference(hint_reference, vm, ap_tracking)?;

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -1,4 +1,5 @@
 use crate::utils::const_path_to_const_name;
+use felt::{Felt, FeltOps};
 use num_bigint::BigInt;
 use pyo3::exceptions::PyValueError;
 use std::{
@@ -7,7 +8,6 @@ use std::{
     rc::Rc,
 };
 
-use cairo_rs::serde::deserialize_program::OffsetValue;
 use cairo_rs::{
     hint_processor::{
         hint_processor_definition::HintReference,
@@ -15,8 +15,9 @@ use cairo_rs::{
     },
     serde::deserialize_program::{ApTracking, Member},
     types::relocatable::Relocatable,
-    vm::{errors::vm_errors::VirtualMachineError, vm_core::VirtualMachine},
+    vm::vm_core::VirtualMachine,
 };
+use cairo_rs::{serde::deserialize_program::OffsetValue, vm::errors::hint_errors::HintError};
 use pyo3::{
     exceptions::PyAttributeError, pyclass, pymethods, IntoPy, PyObject, PyResult, Python,
     ToPyObject,
@@ -148,7 +149,7 @@ impl PyIds {
         vm: &PyVM,
         references: &HashMap<String, HintReference>,
         ap_tracking: &ApTracking,
-        constants: &HashMap<String, BigInt>,
+        constants: &HashMap<String, Felt>,
         struct_types: Rc<HashMap<String, HashMap<String, Member>>>,
     ) -> PyIds {
         PyIds {
@@ -244,7 +245,7 @@ pub fn get_value_from_reference(
 ) -> PyResult<PyMaybeRelocatable> {
     // //First handle case on only immediate
     if let OffsetValue::Immediate(num) = &hint_reference.offset1 {
-        return Ok(PyMaybeRelocatable::from(num));
+        return Ok(PyMaybeRelocatable::from(num.to_bigint()));
     }
     //Then calculate address
     let var_addr = compute_addr_from_reference(hint_reference, vm, ap_tracking)?;
@@ -256,7 +257,7 @@ pub fn get_value_from_reference(
     };
 
     value
-        .ok_or_else(|| PyValueError::new_err(VirtualMachineError::FailedToGetIds.to_string()))
+        .ok_or_else(|| PyValueError::new_err(HintError::FailedToGetIds.to_string()))
         .map(PyMaybeRelocatable::from)
 }
 
@@ -274,11 +275,8 @@ pub fn compute_addr_from_reference(
 #[cfg(test)]
 mod tests {
     use crate::{memory::PyMemory, relocatable::PyRelocatable};
-    use cairo_rs::{
-        bigint,
-        types::{instruction::Register, relocatable::MaybeRelocatable},
-    };
-    use num_bigint::{BigInt, Sign};
+    use cairo_rs::types::{instruction::Register, relocatable::MaybeRelocatable};
+    use felt::NewFelt;
     use pyo3::{types::PyDict, PyCell};
 
     use super::*;
@@ -309,11 +307,7 @@ mod tests {
     #[test]
     fn ids_get_test() {
         Python::with_gil(|py| {
-            let vm = PyVM::new(
-                BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
-                false,
-                Vec::new(),
-            );
+            let vm = PyVM::new(false);
             for _ in 0..2 {
                 vm.vm.borrow_mut().add_memory_segment();
             }
@@ -323,15 +317,12 @@ mod tests {
 
             //Create constants
             let mut constants = HashMap::new();
-            constants.insert(String::from("CONST"), bigint!(3));
+            constants.insert(String::from("CONST"), Felt::new(3));
 
             //Insert ids.a into memory
             vm.vm
                 .borrow_mut()
-                .insert_value(
-                    &Relocatable::from((1, 1)),
-                    &MaybeRelocatable::from(bigint!(2)),
-                )
+                .insert_value(&Relocatable::from((1, 1)), &MaybeRelocatable::from(2))
                 .unwrap();
 
             let memory = PyMemory::new(&vm);
@@ -366,11 +357,11 @@ memory[fp+2] = ids.CONST
             //Check ids.a is now at memory[fp]
             assert_eq!(
                 vm.vm.borrow().get_maybe(&Relocatable::from((1, 0))),
-                Ok(Some(MaybeRelocatable::from(bigint!(2))))
+                Ok(Some(MaybeRelocatable::from(2)))
             );
             assert_eq!(
                 vm.vm.borrow().get_maybe(&Relocatable::from((1, 2))),
-                Ok(Some(MaybeRelocatable::from(bigint!(3))))
+                Ok(Some(MaybeRelocatable::from(3)))
             );
         });
     }
@@ -378,11 +369,7 @@ memory[fp+2] = ids.CONST
     #[test]
     fn ids_get_simple_struct() {
         Python::with_gil(|py| {
-            let vm = PyVM::new(
-                BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
-                false,
-                Vec::new(),
-            );
+            let vm = PyVM::new(false);
             for _ in 0..2 {
                 vm.vm.borrow_mut().add_memory_segment();
             }
@@ -405,10 +392,7 @@ memory[fp+2] = ids.CONST
             //Insert ids.a.x into memory
             vm.vm
                 .borrow_mut()
-                .insert_value(
-                    &Relocatable::from((1, 0)),
-                    &MaybeRelocatable::from(bigint!(55)),
-                )
+                .insert_value(&Relocatable::from((1, 0)), &MaybeRelocatable::from(55))
                 .unwrap();
 
             //Insert ids.a.ptr into memory
@@ -450,7 +434,7 @@ memory[fp + 2] = ids.SimpleStruct.SIZE
             //Check ids.a.x is now at memory[fp]
             assert_eq!(
                 vm.vm.borrow().get_maybe(&Relocatable::from((1, 0))),
-                Ok(Some(MaybeRelocatable::from(bigint!(55))))
+                Ok(Some(MaybeRelocatable::from(Felt::new(55))))
             );
             //Check ids.a.ptr is now at memory[fp + 1]
             assert_eq!(
@@ -460,7 +444,7 @@ memory[fp + 2] = ids.SimpleStruct.SIZE
             //Check ids.SimpleStruct.SIZE is now at memory[fp + 2]
             assert_eq!(
                 vm.vm.borrow().get_maybe(&Relocatable::from((1, 2))),
-                Ok(Some(MaybeRelocatable::from(bigint!(2))))
+                Ok(Some(MaybeRelocatable::from(Felt::new(2))))
             );
 
             //ids.a.y does not exist
@@ -475,11 +459,7 @@ memory[fp + 2] = ids.SimpleStruct.SIZE
     #[test]
     fn ids_get_nested_struct() {
         Python::with_gil(|py| {
-            let vm = PyVM::new(
-                BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
-                false,
-                Vec::new(),
-            );
+            let vm = PyVM::new(false);
             for _ in 0..2 {
                 vm.vm.borrow_mut().add_memory_segment();
             }
@@ -526,10 +506,7 @@ memory[fp + 2] = ids.SimpleStruct.SIZE
             //Insert ids.ns.x into memory
             vm.vm
                 .borrow_mut()
-                .insert_value(
-                    &Relocatable::from((1, 0)),
-                    &MaybeRelocatable::from(bigint!(55)),
-                )
+                .insert_value(&Relocatable::from((1, 0)), &MaybeRelocatable::from(55))
                 .unwrap();
 
             //Insert ids.ns.ptr into memory
@@ -571,7 +548,7 @@ memory[fp + 1] = ids.ns.struct.address_
             //Check ids.Struct.SIZE is now at memory[fp]
             assert_eq!(
                 vm.vm.borrow().get_maybe(&Relocatable::from((1, 3))),
-                Ok(Some(MaybeRelocatable::from(bigint!(0))))
+                Ok(Some(MaybeRelocatable::from(0)))
             );
             //Check that address of ids.ns.struct is now at memory[fp + 1]
             assert_eq!(
@@ -584,11 +561,7 @@ memory[fp + 1] = ids.ns.struct.address_
     #[test]
     fn ids_get_from_pointer() {
         Python::with_gil(|py| {
-            let vm = PyVM::new(
-                BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
-                false,
-                Vec::new(),
-            );
+            let vm = PyVM::new(false);
             for _ in 0..3 {
                 vm.vm.borrow_mut().add_memory_segment();
             }
@@ -647,11 +620,7 @@ assert ids.ssp_x_ptr == 5
     #[test]
     fn ids_failed_get_test() {
         Python::with_gil(|py| {
-            let vm = PyVM::new(
-                BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
-                false,
-                Vec::new(),
-            );
+            let vm = PyVM::new(false);
             for _ in 0..2 {
                 vm.vm.borrow_mut().add_memory_segment();
             }
@@ -691,11 +660,7 @@ assert ids.ssp_x_ptr == 5
     #[test]
     fn ids_set_test() {
         Python::with_gil(|py| {
-            let vm = PyVM::new(
-                BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
-                false,
-                Vec::new(),
-            );
+            let vm = PyVM::new(false);
             for _ in 0..2 {
                 vm.vm.borrow_mut().add_memory_segment();
             }
@@ -705,14 +670,11 @@ assert ids.ssp_x_ptr == 5
 
             //Create constants
             let mut constants = HashMap::new();
-            constants.insert(String::from("CONST"), bigint!(3));
+            constants.insert(String::from("CONST"), Felt::new(3));
 
             vm.vm
                 .borrow_mut()
-                .insert_value(
-                    &Relocatable::from((1, 0)),
-                    &MaybeRelocatable::from(bigint!(2)),
-                )
+                .insert_value(&Relocatable::from((1, 0)), &MaybeRelocatable::from(2))
                 .unwrap();
 
             let memory = PyMemory::new(&vm);
@@ -745,7 +707,7 @@ assert ids.ssp_x_ptr == 5
             //Check ids.a now contains memory[fp]
             assert_eq!(
                 vm.vm.borrow().get_maybe(&Relocatable::from((1, 1))),
-                Ok(Some(MaybeRelocatable::from(bigint!(2))))
+                Ok(Some(MaybeRelocatable::from(2)))
             );
 
             //ids.b does not exist
@@ -763,11 +725,7 @@ assert ids.ssp_x_ptr == 5
     #[test]
     fn ids_set_struct_attribute() {
         Python::with_gil(|py| {
-            let vm = PyVM::new(
-                BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
-                false,
-                Vec::new(),
-            );
+            let vm = PyVM::new(false);
             for _ in 0..2 {
                 vm.vm.borrow_mut().add_memory_segment();
             }
@@ -822,7 +780,7 @@ ids.struct.ptr = ids.fp
             //Check ids.struct.x now contains 5
             assert_eq!(
                 vm.vm.borrow().get_maybe(&Relocatable::from((1, 0))),
-                Ok(Some(MaybeRelocatable::from(bigint!(5))))
+                Ok(Some(MaybeRelocatable::from(5)))
             );
             //Check ids.struct.x now contains fp's address
             assert_eq!(
@@ -842,11 +800,7 @@ ids.struct.ptr = ids.fp
     #[test]
     fn ids_ap_tracked_ref() {
         Python::with_gil(|py| {
-            let vm = PyVM::new(
-                BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
-                false,
-                Vec::new(),
-            );
+            let vm = PyVM::new(false);
             for _ in 0..2 {
                 vm.vm.borrow_mut().add_memory_segment();
             }
@@ -921,7 +875,7 @@ memory[fp] = ids.ok_ref
             //Check ids.a is now at memory[fp]
             assert_eq!(
                 vm.vm.borrow().get_maybe(&Relocatable::from((1, 0))),
-                Ok(Some(MaybeRelocatable::from(bigint!(5))))
+                Ok(Some(MaybeRelocatable::from(5)))
             );
 
             let code = r"ids.bad_ref";
@@ -931,15 +885,14 @@ memory[fp] = ids.ok_ref
             assert!(py_result
                 .unwrap_err()
                 .to_string()
-                .contains(&VirtualMachineError::InvalidTrackingGroup(1, 0).to_string()));
+                .contains(&HintError::InvalidTrackingGroup(1, 0).to_string()));
 
             let code = r"ids.none_ref";
 
             let py_result = py.run(code, Some(globals), None);
 
             assert!(py_result.unwrap_err().to_string().contains(
-                &PyValueError::new_err(VirtualMachineError::NoneApTrackingData.to_string())
-                    .to_string()
+                &PyValueError::new_err(HintError::NoneApTrackingData.to_string()).to_string()
             ));
         });
     }
@@ -947,11 +900,7 @@ memory[fp] = ids.ok_ref
     #[test]
     fn ids_no_register_ref() {
         Python::with_gil(|py| {
-            let vm = PyVM::new(
-                BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
-                false,
-                Vec::new(),
-            );
+            let vm = PyVM::new(false);
             for _ in 0..2 {
                 vm.vm.borrow_mut().add_memory_segment();
             }
@@ -962,8 +911,8 @@ memory[fp] = ids.ok_ref
             references.insert(
                 String::from("imm_ref"),
                 HintReference {
-                    offset1: OffsetValue::Immediate(bigint!(imm)),
-                    offset2: OffsetValue::Immediate(bigint!(0)),
+                    offset1: OffsetValue::Immediate(Felt::from(imm)),
+                    offset2: OffsetValue::Immediate(Felt::from(0)),
                     dereference: true,
                     ap_tracking_data: None,
                     cairo_type: None,
@@ -1010,7 +959,7 @@ memory[fp] = ids.ok_ref
             //Check ids.a is now at memory[fp]
             assert_eq!(
                 vm.vm.borrow().get_maybe(&Relocatable::from((1, 0))),
-                Ok(Some(MaybeRelocatable::from(bigint!(imm))))
+                Ok(Some(MaybeRelocatable::from(imm)))
             );
 
             let code = r"ids.no_reg_ref";
@@ -1020,18 +969,14 @@ memory[fp] = ids.ok_ref
             assert!(py_result
                 .unwrap_err()
                 .to_string()
-                .contains(&VirtualMachineError::NoRegisterInReference.to_string()));
+                .contains(&HintError::NoRegisterInReference.to_string()));
         });
     }
 
     #[test]
     fn ids_reference_with_immediate() {
         Python::with_gil(|py| {
-            let vm = PyVM::new(
-                BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
-                false,
-                Vec::new(),
-            );
+            let vm = PyVM::new(false);
             for _ in 0..2 {
                 vm.vm.borrow_mut().add_memory_segment();
             }

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -1,5 +1,5 @@
 use crate::utils::const_path_to_const_name;
-use felt::{Felt, FeltOps};
+use cairo_felt::{Felt, FeltOps};
 use num_bigint::BigInt;
 use pyo3::exceptions::PyValueError;
 use std::{
@@ -8,16 +8,16 @@ use std::{
     rc::Rc,
 };
 
-use cairo_rs::{
+use cairo_vm::{
     hint_processor::{
         hint_processor_definition::HintReference,
-        hint_processor_utils::compute_addr_from_reference as cairo_rs_compute_addr_from_reference,
+        hint_processor_utils::compute_addr_from_reference as cairo_vm_compute_addr_from_reference,
     },
     serde::deserialize_program::{ApTracking, Member},
     types::relocatable::Relocatable,
     vm::vm_core::VirtualMachine,
 };
-use cairo_rs::{serde::deserialize_program::OffsetValue, vm::errors::hint_errors::HintError};
+use cairo_vm::{serde::deserialize_program::OffsetValue, vm::errors::hint_errors::HintError};
 use pyo3::{
     exceptions::PyAttributeError, pyclass, pymethods, IntoPy, PyObject, PyResult, Python,
     ToPyObject,
@@ -269,14 +269,14 @@ pub fn compute_addr_from_reference(
     //ApTracking of the Hint itself
     hint_ap_tracking: &ApTracking,
 ) -> PyResult<Relocatable> {
-    cairo_rs_compute_addr_from_reference(hint_reference, vm, hint_ap_tracking)
+    cairo_vm_compute_addr_from_reference(hint_reference, vm, hint_ap_tracking)
         .map_err(|err| PyValueError::new_err(err.to_string()))
 }
 #[cfg(test)]
 mod tests {
     use crate::{memory::PyMemory, relocatable::PyRelocatable};
-    use cairo_rs::types::{instruction::Register, relocatable::MaybeRelocatable};
-    use felt::NewFelt;
+    use cairo_felt::NewFelt;
+    use cairo_vm::types::{instruction::Register, relocatable::MaybeRelocatable};
     use pyo3::{types::PyDict, PyCell};
 
     use super::*;

--- a/src/instruction_location.rs
+++ b/src/instruction_location.rs
@@ -1,4 +1,4 @@
-use cairo_rs::serde::deserialize_program::{InputFile, Location};
+use cairo_vm::serde::deserialize_program::{InputFile, Location};
 use pyo3::prelude::*;
 
 #[pyclass]

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -3,11 +3,11 @@ use crate::{
     utils::to_py_error,
     vm_core::PyVM,
 };
-use cairo_rs::{
+use cairo_felt::FeltOps;
+use cairo_vm::{
     types::relocatable::{MaybeRelocatable, Relocatable},
     vm::vm_core::VirtualMachine,
 };
-use felt::FeltOps;
 use num_bigint::BigInt;
 use pyo3::{
     exceptions::{PyTypeError, PyValueError},
@@ -106,7 +106,7 @@ mod test {
     use crate::relocatable::PyMaybeRelocatable::RelocatableValue;
     use crate::vm_core::PyVM;
     use crate::{memory::PyMemory, relocatable::PyRelocatable};
-    use cairo_rs::types::relocatable::{MaybeRelocatable, Relocatable};
+    use cairo_vm::types::relocatable::{MaybeRelocatable, Relocatable};
     use num_bigint::BigInt;
     use pyo3::PyCell;
     use pyo3::{types::PyDict, Python};

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -219,11 +219,11 @@ assert memory[ap] == fp
                 .unwrap();
             vm.vm
                 .borrow_mut()
-                .insert_value(&Relocatable::from((1, 0)), &Relocatable::from((2, 0)))
+                .insert_value(&Relocatable::from((1, 0)), Relocatable::from((2, 0)))
                 .unwrap();
             vm.vm
                 .borrow_mut()
-                .insert_value(&Relocatable::from((1, 1)), &Relocatable::from((3, 0)))
+                .insert_value(&Relocatable::from((1, 1)), Relocatable::from((3, 0)))
                 .unwrap();
 
             let maybe_relocatable = MaybeRelocatable::from((1, 0));
@@ -271,11 +271,11 @@ assert memory[ap] == fp
                 .unwrap();
             vm.vm
                 .borrow_mut()
-                .insert_value(&Relocatable::from((1, 0)), &Relocatable::from((2, 0)))
+                .insert_value(&Relocatable::from((1, 0)), Relocatable::from((2, 0)))
                 .unwrap();
             vm.vm
                 .borrow_mut()
-                .insert_value(&Relocatable::from((1, 2)), &Relocatable::from((3, 0)))
+                .insert_value(&Relocatable::from((1, 2)), Relocatable::from((3, 0)))
                 .unwrap();
 
             let maybe_relocatable = MaybeRelocatable::from((1, 0));

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -7,12 +7,13 @@ use cairo_rs::{
     types::relocatable::{MaybeRelocatable, Relocatable},
     vm::vm_core::VirtualMachine,
 };
+use felt::FeltOps;
 use num_bigint::BigInt;
 use pyo3::{
     exceptions::{PyTypeError, PyValueError},
     prelude::*,
 };
-use std::{borrow::Cow, cell::RefCell, rc::Rc};
+use std::{cell::RefCell, rc::Rc};
 
 const MEMORY_GET_ERROR_MSG: &str = "Failed to get value from Cairo memory";
 const MEMORY_SET_ERROR_MSG: &str = "Failed to set value to Cairo memory";
@@ -93,31 +94,27 @@ impl PyMemory {
             .get_integer_range(&Relocatable::from(&addr), size)
             .map_err(to_py_error)?
             .into_iter()
-            .map(Cow::into_owned)
+            .map(|num| num.into_owned().to_bigint())
             .collect())
     }
 }
 
 #[cfg(test)]
 mod test {
+    use crate::bigint;
     use crate::relocatable::PyMaybeRelocatable;
     use crate::relocatable::PyMaybeRelocatable::RelocatableValue;
     use crate::vm_core::PyVM;
     use crate::{memory::PyMemory, relocatable::PyRelocatable};
-    use cairo_rs::bigint;
     use cairo_rs::types::relocatable::{MaybeRelocatable, Relocatable};
-    use num_bigint::{BigInt, Sign};
+    use num_bigint::BigInt;
     use pyo3::PyCell;
     use pyo3::{types::PyDict, Python};
 
     #[test]
     fn memory_insert_test() {
         Python::with_gil(|py| {
-            let vm = PyVM::new(
-                BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
-                false,
-                Vec::new(),
-            );
+            let vm = PyVM::new(false);
             for _ in 0..2 {
                 vm.vm.borrow_mut().add_memory_segment();
             }
@@ -143,11 +140,7 @@ mod test {
     #[test]
     fn memory_insert_ocuppied_address_error_test() {
         Python::with_gil(|py| {
-            let vm = PyVM::new(
-                BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
-                false,
-                Vec::new(),
-            );
+            let vm = PyVM::new(false);
             for _ in 0..2 {
                 vm.vm.borrow_mut().add_memory_segment();
             }
@@ -177,11 +170,7 @@ memory[ap] = 3
     #[test]
     fn memory_get_test() {
         Python::with_gil(|py| {
-            let vm = PyVM::new(
-                BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
-                false,
-                Vec::new(),
-            );
+            let vm = PyVM::new(false);
             for _ in 0..2 {
                 vm.vm.borrow_mut().add_memory_segment();
             }
@@ -214,11 +203,7 @@ assert memory[ap] == fp
     #[test]
     fn get_range() {
         Python::with_gil(|py| {
-            let vm = PyVM::new(
-                BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
-                false,
-                Vec::new(),
-            );
+            let vm = PyVM::new(false);
 
             for _ in 0..2 {
                 vm.vm.borrow_mut().add_memory_segment();
@@ -230,7 +215,7 @@ assert memory[ap] == fp
 
             vm.vm
                 .borrow_mut()
-                .insert_value(&Relocatable::from((0, 0)), bigint!(2345108766317314046_u64))
+                .insert_value(&Relocatable::from((0, 0)), 2345108766317314046)
                 .unwrap();
             vm.vm
                 .borrow_mut()
@@ -270,11 +255,7 @@ assert memory[ap] == fp
     #[test]
     fn get_range_with_gap() {
         Python::with_gil(|py| {
-            let vm = PyVM::new(
-                BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
-                false,
-                Vec::new(),
-            );
+            let vm = PyVM::new(false);
 
             for _ in 0..2 {
                 vm.vm.borrow_mut().add_memory_segment();
@@ -286,7 +267,7 @@ assert memory[ap] == fp
 
             vm.vm
                 .borrow_mut()
-                .insert_value(&Relocatable::from((0, 0)), bigint!(2345108766317314046_u64))
+                .insert_value(&Relocatable::from((0, 0)), 2345108766317314046)
                 .unwrap();
             vm.vm
                 .borrow_mut()
@@ -314,11 +295,7 @@ assert memory[ap] == fp
     // Test that get_range_as_ints() works as intended.
     #[test]
     fn get_range_as_ints() {
-        let vm = PyVM::new(
-            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
-            false,
-            Vec::new(),
-        );
+        let vm = PyVM::new(false);
         let memory = PyMemory::new(&vm);
 
         let addr = {
@@ -327,12 +304,7 @@ assert memory[ap] == fp
 
             vm.load_data(
                 &MaybeRelocatable::from(&addr),
-                vec![
-                    bigint!(1).into(),
-                    bigint!(2).into(),
-                    bigint!(3).into(),
-                    bigint!(4).into(),
-                ],
+                &vec![1.into(), 2.into(), 3.into(), 4.into()],
             )
             .expect("memory insertion failed");
 
@@ -350,11 +322,7 @@ assert memory[ap] == fp
     // Test that get_range_as_ints() fails when not all values are integers.
     #[test]
     fn get_range_as_ints_mixed() {
-        let vm = PyVM::new(
-            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
-            false,
-            Vec::new(),
-        );
+        let vm = PyVM::new(false);
         let memory = PyMemory::new(&vm);
 
         let addr = {
@@ -363,11 +331,11 @@ assert memory[ap] == fp
 
             vm.load_data(
                 &MaybeRelocatable::from(&addr),
-                vec![
-                    bigint!(1).into(),
-                    bigint!(2).into(),
+                &vec![
+                    1.into(),
+                    2.into(),
                     MaybeRelocatable::RelocatableValue((1, 2).into()),
-                    bigint!(4).into(),
+                    4.into(),
                 ],
             )
             .expect("memory insertion failed");
@@ -384,11 +352,7 @@ assert memory[ap] == fp
     // segments.
     #[test]
     fn get_range_as_ints_incomplete() {
-        let vm = PyVM::new(
-            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
-            false,
-            Vec::new(),
-        );
+        let vm = PyVM::new(false);
         let memory = PyMemory::new(&vm);
 
         let addr = {
@@ -397,12 +361,7 @@ assert memory[ap] == fp
 
             vm.load_data(
                 &MaybeRelocatable::from(&addr),
-                vec![
-                    bigint!(1).into(),
-                    bigint!(2).into(),
-                    bigint!(3).into(),
-                    bigint!(4).into(),
-                ],
+                &vec![1.into(), 2.into(), 3.into(), 4.into()],
             )
             .expect("memory insertion failed");
 

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -8,7 +8,7 @@ use cairo_vm::{
     types::relocatable::{MaybeRelocatable, Relocatable},
     vm::vm_core::VirtualMachine,
 };
-use num_bigint::BigInt;
+use num_bigint::BigUint;
 use pyo3::{
     exceptions::{PyTypeError, PyValueError},
     prelude::*,
@@ -87,27 +87,27 @@ impl PyMemory {
     }
 
     /// Return a continuous section of memory as a vector of integers.
-    pub fn get_range_as_ints(&self, addr: PyRelocatable, size: usize) -> PyResult<Vec<BigInt>> {
+    pub fn get_range_as_ints(&self, addr: PyRelocatable, size: usize) -> PyResult<Vec<BigUint>> {
         Ok(self
             .vm
             .borrow()
             .get_integer_range(&Relocatable::from(&addr), size)
             .map_err(to_py_error)?
             .into_iter()
-            .map(|num| num.into_owned().to_bigint())
+            .map(|num| num.into_owned().to_biguint())
             .collect())
     }
 }
 
 #[cfg(test)]
 mod test {
-    use crate::bigint;
+    use crate::biguint;
     use crate::relocatable::PyMaybeRelocatable;
     use crate::relocatable::PyMaybeRelocatable::RelocatableValue;
     use crate::vm_core::PyVM;
     use crate::{memory::PyMemory, relocatable::PyRelocatable};
     use cairo_vm::types::relocatable::{MaybeRelocatable, Relocatable};
-    use num_bigint::BigInt;
+    use num_bigint::BigUint;
     use pyo3::PyCell;
     use pyo3::{types::PyDict, Python};
 
@@ -315,7 +315,12 @@ assert memory[ap] == fp
             memory
                 .get_range_as_ints(addr.into(), 4)
                 .expect("get_range_as_ints() failed"),
-            vec![bigint!(1), bigint!(2), bigint!(3), bigint!(4)],
+            vec![
+                biguint!(1_u32),
+                biguint!(2_u32),
+                biguint!(3_u32),
+                biguint!(4_u32)
+            ],
         );
     }
 

--- a/src/memory_segments.rs
+++ b/src/memory_segments.rs
@@ -154,8 +154,7 @@ mod test {
                 .unwrap()
                 .unwrap()
                 .get_relocatable()
-                .unwrap()
-                .clone();
+                .unwrap();
 
             assert_eq!(
                 vm_ref
@@ -182,8 +181,7 @@ mod test {
                 .unwrap()
                 .unwrap()
                 .get_relocatable()
-                .unwrap()
-                .clone();
+                .unwrap();
 
             assert_eq!(
                 vm_ref

--- a/src/memory_segments.rs
+++ b/src/memory_segments.rs
@@ -50,15 +50,7 @@ impl PySegmentManager {
                     )?;
                     segment_ptr
                 }
-                _ => {
-                    let mut value: MaybeRelocatable = arg.extract::<PyMaybeRelocatable>(py)?.into();
-                    if apply_modulo_to_args {
-                        value = value
-                            .mod_floor(self.vm.borrow().get_prime())
-                            .map_err(to_py_error)?;
-                    }
-                    value
-                }
+                _ => arg.extract::<PyMaybeRelocatable>(py)?.into(),
             })
             .to_object(py),
         )
@@ -75,7 +67,7 @@ impl PySegmentManager {
         let ptr: MaybeRelocatable = ptr.into();
 
         let arg_iter = PyIterator::from_object(py, &arg)?;
-        let mut data = Vec::new();
+        let mut data = Vec::<MaybeRelocatable>::new();
         for value in arg_iter {
             data.push(
                 self.gen_arg(py, value?.to_object(py), apply_modulo_to_args)?
@@ -86,7 +78,7 @@ impl PySegmentManager {
 
         self.vm
             .borrow_mut()
-            .load_data(&ptr, data)
+            .load_data(&ptr, &data)
             .map(|x| PyMaybeRelocatable::from(x).to_object(py))
             .map_err(to_py_error)
     }
@@ -106,17 +98,13 @@ impl PySegmentManager {
 mod test {
     use super::PySegmentManager;
     use crate::{memory::PyMemory, relocatable::PyMaybeRelocatable, vm_core::PyVM};
-    use cairo_rs::{bigint, types::relocatable::Relocatable};
-    use num_bigint::{BigInt, Sign};
+    use cairo_rs::types::relocatable::{MaybeRelocatable, Relocatable};
+    use felt::{Felt, NewFelt};
     use pyo3::{Python, ToPyObject};
 
     #[test]
     fn add_segment_test() {
-        let vm = PyVM::new(
-            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
-            false,
-            Vec::new(),
-        );
+        let vm = PyVM::new(false);
         let segments = PySegmentManager::new(&vm, PyMemory::new(&vm));
         assert!(segments.add().is_ok());
     }
@@ -124,11 +112,7 @@ mod test {
     #[test]
     fn write_arg_test() {
         Python::with_gil(|py| {
-            let vm = PyVM::new(
-                BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
-                false,
-                Vec::new(),
-            );
+            let vm = PyVM::new(false);
             let segments = PySegmentManager::new(&vm, PyMemory::new(&vm));
 
             let ptr = segments.add().unwrap();
@@ -153,7 +137,7 @@ mod test {
                     .unwrap()
                     .get_int_ref()
                     .unwrap(),
-                &bigint!(1),
+                &Felt::new(1),
             );
             assert_eq!(
                 vm_ref
@@ -162,7 +146,7 @@ mod test {
                     .unwrap()
                     .get_int_ref()
                     .unwrap(),
-                &bigint!(2),
+                &Felt::new(2),
             );
 
             let relocatable = vm_ref
@@ -180,7 +164,7 @@ mod test {
                     .unwrap()
                     .get_int_ref()
                     .unwrap(),
-                &bigint!(3),
+                &Felt::new(3),
             );
             assert_eq!(
                 vm_ref
@@ -189,7 +173,7 @@ mod test {
                     .unwrap()
                     .get_int_ref()
                     .unwrap(),
-                &bigint!(4),
+                &Felt::new(4),
             );
             assert!(vm_ref.get_maybe(&(&relocatable + 2)).unwrap().is_none());
 
@@ -208,7 +192,7 @@ mod test {
                     .unwrap()
                     .get_int_ref()
                     .unwrap(),
-                &bigint!(5),
+                &Felt::new(5),
             );
             assert_eq!(
                 vm_ref
@@ -217,7 +201,7 @@ mod test {
                     .unwrap()
                     .get_int_ref()
                     .unwrap(),
-                &bigint!(6),
+                &Felt::new(6),
             );
             assert!(vm_ref.get_maybe(&(&relocatable + 2)).unwrap().is_none());
 
@@ -230,11 +214,7 @@ mod test {
 
     #[test]
     fn add_temp_segment_test() {
-        let mut vm = PyVM::new(
-            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
-            false,
-            Vec::new(),
-        );
+        let mut vm = PyVM::new(false);
         let memory = PyMemory::new(&vm);
         let mut segments = PySegmentManager::new(&mut vm, memory);
         assert!(segments.add_temp_segment().is_ok());
@@ -242,11 +222,7 @@ mod test {
 
     #[test]
     fn get_segment_used_size() {
-        let vm = PyVM::new(
-            BigInt::new(Sign::Plus, vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
-            false,
-            Vec::new(),
-        );
+        let vm = PyVM::new(false);
 
         let memory = PyMemory::new(&vm);
         let segments = PySegmentManager::new(&vm, memory);
@@ -257,11 +233,11 @@ mod test {
             .borrow_mut()
             .load_data(
                 &Relocatable::from(&segment).into(),
-                vec![
-                    bigint!(1).into(),
-                    bigint!(2).into(),
-                    bigint!(3).into(),
-                    bigint!(4).into(),
+                &vec![
+                    MaybeRelocatable::from(1),
+                    MaybeRelocatable::from(2),
+                    MaybeRelocatable::from(3),
+                    MaybeRelocatable::from(4),
                 ],
             )
             .is_ok());

--- a/src/memory_segments.rs
+++ b/src/memory_segments.rs
@@ -4,7 +4,7 @@ use crate::{
     utils::to_py_error,
     vm_core::PyVM,
 };
-use cairo_rs::{types::relocatable::MaybeRelocatable, vm::vm_core::VirtualMachine};
+use cairo_vm::{types::relocatable::MaybeRelocatable, vm::vm_core::VirtualMachine};
 use pyo3::{prelude::*, types::PyIterator};
 use std::{cell::RefCell, rc::Rc};
 
@@ -98,8 +98,8 @@ impl PySegmentManager {
 mod test {
     use super::PySegmentManager;
     use crate::{memory::PyMemory, relocatable::PyMaybeRelocatable, vm_core::PyVM};
-    use cairo_rs::types::relocatable::{MaybeRelocatable, Relocatable};
-    use felt::{Felt, NewFelt};
+    use cairo_felt::{Felt, NewFelt};
+    use cairo_vm::types::relocatable::{MaybeRelocatable, Relocatable};
     use pyo3::{Python, ToPyObject};
 
     #[test]

--- a/src/range_check.rs
+++ b/src/range_check.rs
@@ -2,6 +2,7 @@ use cairo_rs::vm::{
     errors::vm_errors::VirtualMachineError, runners::builtin_runner::RangeCheckBuiltinRunner,
 };
 
+use felt::FeltOps;
 use num_bigint::BigInt;
 use pyo3::prelude::*;
 
@@ -9,18 +10,21 @@ use pyo3::prelude::*;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PyRangeCheck {
     #[pyo3(get)]
-    bound: BigInt,
+    bound: Option<BigInt>,
 }
 
 #[pymethods]
 impl PyRangeCheck {
     #[new]
-    pub fn new(value: BigInt) -> Self {
+    pub fn new(value: Option<BigInt>) -> Self {
         Self { bound: value }
     }
 
     pub fn __repr__(&self) -> String {
-        format!("Bound: {}", self.bound)
+        match self.bound {
+            Some(ref bound) => format!("Bound: {}", bound),
+            None => String::from("None"),
+        }
     }
 }
 
@@ -28,7 +32,7 @@ impl From<Result<&RangeCheckBuiltinRunner, VirtualMachineError>> for PyRangeChec
     fn from(val: Result<&RangeCheckBuiltinRunner, VirtualMachineError>) -> Self {
         match val {
             Ok(range_check_builtin) => PyRangeCheck::from(range_check_builtin),
-            Err(_err) => PyRangeCheck::new(BigInt::from(0)),
+            Err(_err) => PyRangeCheck::new(None),
         }
     }
 }
@@ -36,7 +40,7 @@ impl From<Result<&RangeCheckBuiltinRunner, VirtualMachineError>> for PyRangeChec
 impl From<&RangeCheckBuiltinRunner> for PyRangeCheck {
     fn from(val: &RangeCheckBuiltinRunner) -> Self {
         Self {
-            bound: val._bound.clone(),
+            bound: val._bound.as_ref().map(|num| num.to_bigint()),
         }
     }
 }
@@ -49,14 +53,12 @@ impl ToPyObject for PyRangeCheck {
 
 #[cfg(test)]
 mod test {
+    use crate::bigint;
+
     use super::PyRangeCheck;
     use super::*;
-    use cairo_rs::{
-        bigint,
-        vm::{
-            errors::vm_errors::VirtualMachineError,
-            runners::builtin_runner::RangeCheckBuiltinRunner,
-        },
+    use cairo_rs::vm::{
+        errors::vm_errors::VirtualMachineError, runners::builtin_runner::RangeCheckBuiltinRunner,
     };
     use num_bigint::BigInt;
     use pyo3::ToPyObject;
@@ -64,15 +66,15 @@ mod test {
     #[test]
     fn py_range_check_new() {
         let value = bigint!(12);
-        let new_py_range_check = PyRangeCheck::new(value.clone());
+        let new_py_range_check = PyRangeCheck::new(Some(value.clone()));
 
-        assert_eq!(new_py_range_check, PyRangeCheck { bound: value });
+        assert_eq!(new_py_range_check, PyRangeCheck { bound: Some(value) });
     }
 
     #[test]
     fn py_range_check_repr() {
         let value = bigint!(12);
-        let new_py_range_check = PyRangeCheck::new(value);
+        let new_py_range_check = PyRangeCheck::new(Some(value));
 
         assert_eq!(new_py_range_check.__repr__(), String::from("Bound: 12"));
     }
@@ -87,7 +89,7 @@ mod test {
 
         assert_eq!(
             PyRangeCheck::from(result_with_range_check_builtin),
-            PyRangeCheck::new(bound)
+            PyRangeCheck::new(Some(bound))
         );
     }
 
@@ -98,7 +100,7 @@ mod test {
 
         assert_eq!(
             PyRangeCheck::from(result_with_range_check_builtin),
-            PyRangeCheck::new(BigInt::from(0))
+            PyRangeCheck::new(None)
         );
     }
 
@@ -110,14 +112,14 @@ mod test {
 
         assert_eq!(
             PyRangeCheck::from(&range_check_builtin),
-            PyRangeCheck::new(bound)
+            PyRangeCheck::new(Some(bound))
         );
     }
 
     #[test]
     fn py_range_check_to_py_object() {
         let value = bigint!(12);
-        let new_py_range_check = PyRangeCheck::new(value.clone());
+        let new_py_range_check = PyRangeCheck::new(Some(value.clone()));
 
         Python::with_gil(|py| {
             let py_object = new_py_range_check
@@ -125,7 +127,7 @@ mod test {
                 .extract::<PyRangeCheck>(py)
                 .unwrap();
 
-            assert_eq!(py_object, PyRangeCheck::new(value));
+            assert_eq!(py_object, PyRangeCheck::new(Some(value)));
         });
     }
 }

--- a/src/range_check.rs
+++ b/src/range_check.rs
@@ -1,8 +1,8 @@
-use cairo_rs::vm::{
+use cairo_vm::vm::{
     errors::vm_errors::VirtualMachineError, runners::builtin_runner::RangeCheckBuiltinRunner,
 };
 
-use felt::FeltOps;
+use cairo_felt::FeltOps;
 use num_bigint::BigInt;
 use pyo3::prelude::*;
 
@@ -57,7 +57,7 @@ mod test {
 
     use super::PyRangeCheck;
     use super::*;
-    use cairo_rs::vm::{
+    use cairo_vm::vm::{
         errors::vm_errors::VirtualMachineError, runners::builtin_runner::RangeCheckBuiltinRunner,
     };
     use num_bigint::BigInt;

--- a/src/range_check.rs
+++ b/src/range_check.rs
@@ -3,20 +3,20 @@ use cairo_vm::vm::{
 };
 
 use cairo_felt::FeltOps;
-use num_bigint::BigInt;
+use num_bigint::BigUint;
 use pyo3::prelude::*;
 
 #[pyclass(name = "RangeCheck")]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PyRangeCheck {
     #[pyo3(get)]
-    bound: Option<BigInt>,
+    bound: Option<BigUint>,
 }
 
 #[pymethods]
 impl PyRangeCheck {
     #[new]
-    pub fn new(value: Option<BigInt>) -> Self {
+    pub fn new(value: Option<BigUint>) -> Self {
         Self { bound: value }
     }
 
@@ -40,7 +40,7 @@ impl From<Result<&RangeCheckBuiltinRunner, VirtualMachineError>> for PyRangeChec
 impl From<&RangeCheckBuiltinRunner> for PyRangeCheck {
     fn from(val: &RangeCheckBuiltinRunner) -> Self {
         Self {
-            bound: val._bound.as_ref().map(|num| num.to_bigint()),
+            bound: val._bound.as_ref().map(|num| num.to_biguint()),
         }
     }
 }
@@ -53,19 +53,19 @@ impl ToPyObject for PyRangeCheck {
 
 #[cfg(test)]
 mod test {
-    use crate::bigint;
+    use crate::biguint;
+    use num_bigint::BigUint;
 
     use super::PyRangeCheck;
     use super::*;
     use cairo_vm::vm::{
         errors::vm_errors::VirtualMachineError, runners::builtin_runner::RangeCheckBuiltinRunner,
     };
-    use num_bigint::BigInt;
     use pyo3::ToPyObject;
 
     #[test]
     fn py_range_check_new() {
-        let value = bigint!(12);
+        let value = biguint!(12_u32);
         let new_py_range_check = PyRangeCheck::new(Some(value.clone()));
 
         assert_eq!(new_py_range_check, PyRangeCheck { bound: Some(value) });
@@ -73,7 +73,7 @@ mod test {
 
     #[test]
     fn py_range_check_repr() {
-        let value = bigint!(12);
+        let value = biguint!(12_u32);
         let new_py_range_check = PyRangeCheck::new(Some(value));
 
         assert_eq!(new_py_range_check.__repr__(), String::from("Bound: 12"));
@@ -82,7 +82,7 @@ mod test {
     #[test]
     fn py_range_check_from_result_ok() {
         let value = 12;
-        let bound = bigint!(1usize << 16).pow(value);
+        let bound = biguint!(1usize << 16).pow(value);
         let range_check_builtin = RangeCheckBuiltinRunner::new(value, value, true);
         let result_with_range_check_builtin: Result<&RangeCheckBuiltinRunner, VirtualMachineError> =
             Ok(&range_check_builtin);
@@ -107,7 +107,7 @@ mod test {
     #[test]
     fn py_range_check_from_range_check_builtin_runner() {
         let value = 12;
-        let bound = bigint!(1usize << 16).pow(value);
+        let bound = biguint!(1usize << 16).pow(value);
         let range_check_builtin = RangeCheckBuiltinRunner::new(value, value, true);
 
         assert_eq!(
@@ -118,7 +118,7 @@ mod test {
 
     #[test]
     fn py_range_check_to_py_object() {
-        let value = bigint!(12);
+        let value = biguint!(12_u32);
         let new_py_range_check = PyRangeCheck::new(Some(value.clone()));
 
         Python::with_gil(|py| {

--- a/src/relocatable.rs
+++ b/src/relocatable.rs
@@ -1,8 +1,8 @@
-use cairo_rs::{
+use cairo_felt::FeltOps;
+use cairo_vm::{
     types::relocatable::{MaybeRelocatable, Relocatable},
     vm::errors::vm_errors::VirtualMachineError,
 };
-use felt::FeltOps;
 use num_bigint::BigInt;
 use pyo3::{exceptions::PyArithmeticError, prelude::*, pyclass::CompareOp};
 
@@ -205,7 +205,7 @@ impl From<BigInt> for PyMaybeRelocatable {
 #[cfg(test)]
 mod test {
     use crate::relocatable::BigInt;
-    use cairo_rs::types::relocatable::MaybeRelocatable;
+    use cairo_vm::types::relocatable::MaybeRelocatable;
     use pyo3::ToPyObject;
     use pyo3::{pyclass::CompareOp, Python};
 

--- a/src/run_context.rs
+++ b/src/run_context.rs
@@ -1,5 +1,5 @@
 use crate::relocatable::PyRelocatable;
-use cairo_rs::types::relocatable::Relocatable;
+use cairo_vm::types::relocatable::Relocatable;
 use pyo3::{pyclass, pymethods};
 
 #[pyclass]

--- a/src/scope_manager.rs
+++ b/src/scope_manager.rs
@@ -1,6 +1,6 @@
 use std::{any::Any, collections::HashMap};
 
-use cairo_rs::{any_box, types::exec_scope::ExecutionScopes};
+use cairo_vm::{any_box, types::exec_scope::ExecutionScopes};
 use pyo3::{pyclass, pymethods, PyErr, PyObject};
 
 use crate::utils::to_py_error;

--- a/src/to_felt_or_relocatable.rs
+++ b/src/to_felt_or_relocatable.rs
@@ -1,4 +1,4 @@
-use num_bigint::BigInt;
+use num_bigint::BigUint;
 use pyo3::prelude::*;
 
 use crate::relocatable::{PyMaybeRelocatable, PyRelocatable};
@@ -12,7 +12,7 @@ impl ToFeltOrRelocatableFunc {
         match any.extract::<PyRelocatable>(py) {
             Ok(rel) => Ok(Into::<PyMaybeRelocatable>::into(rel).to_object(py)),
             Err(_) => Ok(Into::<PyMaybeRelocatable>::into(
-                any.call_method0(py, "__int__")?.extract::<BigInt>(py)?,
+                any.call_method0(py, "__int__")?.extract::<BigUint>(py)?,
             )
             .to_object(py)),
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,6 @@
 use cairo_felt::{Felt, FeltOps};
 use cairo_vm::vm::errors::vm_errors::VirtualMachineError;
-use num_bigint::BigInt;
+use num_bigint::BigUint;
 use pyo3::{exceptions::PyValueError, PyErr};
 use std::{collections::HashMap, fmt::Display};
 
@@ -15,25 +15,25 @@ pub fn to_py_error<T: Display>(error: T) -> PyErr {
 }
 
 #[macro_export]
-macro_rules! bigint {
+macro_rules! biguint {
     ($val : expr) => {
-        Into::<BigInt>::into($val)
+        Into::<BigUint>::into($val)
     };
 }
 
-pub fn const_path_to_const_name(constants: &HashMap<String, Felt>) -> HashMap<String, BigInt> {
+pub fn const_path_to_const_name(constants: &HashMap<String, Felt>) -> HashMap<String, BigUint> {
     constants
         .iter()
         .map(|(name, value)| {
             let name = name.rsplit('.').next().unwrap_or(name);
-            (name.to_string(), value.to_bigint())
+            (name.to_string(), value.to_biguint())
         })
         .collect()
 }
 
-//Tries to convert a BigInt value to usize
-pub fn bigint_to_usize(bigint: &BigInt) -> Result<usize, VirtualMachineError> {
-    bigint
+//Tries to convert a biguint value to usize
+pub fn biguint_to_usize(biguint: &BigUint) -> Result<usize, VirtualMachineError> {
+    biguint
         .try_into()
         .map_err(|_| VirtualMachineError::BigintToUsizeFail)
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,5 @@
-use cairo_rs::vm::errors::vm_errors::VirtualMachineError;
-use felt::{Felt, FeltOps};
+use cairo_felt::{Felt, FeltOps};
+use cairo_vm::vm::errors::vm_errors::VirtualMachineError;
 use num_bigint::BigInt;
 use pyo3::{exceptions::PyValueError, PyErr};
 use std::{collections::HashMap, fmt::Display};

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,5 @@
+use cairo_rs::vm::errors::vm_errors::VirtualMachineError;
+use felt::{Felt, FeltOps};
 use num_bigint::BigInt;
 use pyo3::{exceptions::PyValueError, PyErr};
 use std::{collections::HashMap, fmt::Display};
@@ -12,12 +14,26 @@ pub fn to_py_error<T: Display>(error: T) -> PyErr {
     PyValueError::new_err(error.to_string())
 }
 
-pub fn const_path_to_const_name(constants: &HashMap<String, BigInt>) -> HashMap<String, BigInt> {
+#[macro_export]
+macro_rules! bigint {
+    ($val : expr) => {
+        Into::<BigInt>::into($val)
+    };
+}
+
+pub fn const_path_to_const_name(constants: &HashMap<String, Felt>) -> HashMap<String, BigInt> {
     constants
         .iter()
         .map(|(name, value)| {
             let name = name.rsplit('.').next().unwrap_or(name);
-            (name.to_string(), value.clone())
+            (name.to_string(), value.to_bigint().clone())
         })
         .collect()
+}
+
+//Tries to convert a BigInt value to usize
+pub fn bigint_to_usize(bigint: &BigInt) -> Result<usize, VirtualMachineError> {
+    bigint
+        .try_into()
+        .map_err(|_| VirtualMachineError::BigintToUsizeFail)
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -26,7 +26,7 @@ pub fn const_path_to_const_name(constants: &HashMap<String, Felt>) -> HashMap<St
         .iter()
         .map(|(name, value)| {
             let name = name.rsplit('.').next().unwrap_or(name);
-            (name.to_string(), value.to_bigint().clone())
+            (name.to_string(), value.to_bigint())
         })
         .collect()
 }

--- a/src/vm_core.rs
+++ b/src/vm_core.rs
@@ -436,11 +436,11 @@ mod test {
             .unwrap();
         vm.vm
             .borrow_mut()
-            .insert_value(&Relocatable::from((1, 0)), &Relocatable::from((2, 0)))
+            .insert_value(&Relocatable::from((1, 0)), Relocatable::from((2, 0)))
             .unwrap();
         vm.vm
             .borrow_mut()
-            .insert_value(&Relocatable::from((1, 1)), &Relocatable::from((3, 0)))
+            .insert_value(&Relocatable::from((1, 1)), Relocatable::from((3, 0)))
             .unwrap();
 
         assert!(vm
@@ -476,11 +476,11 @@ mod test {
             .unwrap();
         vm.vm
             .borrow_mut()
-            .insert_value(&Relocatable::from((1, 0)), &Relocatable::from((2, 0)))
+            .insert_value(&Relocatable::from((1, 0)), Relocatable::from((2, 0)))
             .unwrap();
         vm.vm
             .borrow_mut()
-            .insert_value(&Relocatable::from((1, 1)), &Relocatable::from((3, 0)))
+            .insert_value(&Relocatable::from((1, 1)), Relocatable::from((3, 0)))
             .unwrap();
 
         let code = "print(ap)";

--- a/src/vm_core.rs
+++ b/src/vm_core.rs
@@ -9,17 +9,17 @@ use crate::{
     memory::PyMemory, memory_segments::PySegmentManager, range_check::PyRangeCheck,
     relocatable::PyRelocatable,
 };
-use cairo_rs::any_box;
-use cairo_rs::hint_processor::hint_processor_definition::HintProcessor;
-use cairo_rs::serde::deserialize_program::Member;
-use cairo_rs::types::exec_scope::ExecutionScopes;
-use cairo_rs::vm::errors::hint_errors::HintError;
-use cairo_rs::vm::vm_core::VirtualMachine;
-use cairo_rs::{
+use cairo_felt::{Felt, FIELD};
+use cairo_vm::any_box;
+use cairo_vm::hint_processor::hint_processor_definition::HintProcessor;
+use cairo_vm::serde::deserialize_program::Member;
+use cairo_vm::types::exec_scope::ExecutionScopes;
+use cairo_vm::vm::errors::hint_errors::HintError;
+use cairo_vm::vm::vm_core::VirtualMachine;
+use cairo_vm::{
     hint_processor::builtin_hint_processor::builtin_hint_processor_definition::HintProcessorData,
     vm::errors::vm_errors::VirtualMachineError,
 };
-use felt::{Felt, FIELD};
 use lazy_static::lazy_static;
 use num_bigint::BigInt;
 use pyo3::{pyclass, pymethods, PyObject, ToPyObject};
@@ -297,7 +297,8 @@ pub(crate) fn update_scope_hint_locals(
 #[cfg(test)]
 mod test {
     use crate::{bigint, relocatable::PyMaybeRelocatable, vm_core::PyVM};
-    use cairo_rs::{
+    use cairo_felt::{Felt, NewFelt};
+    use cairo_vm::{
         hint_processor::{
             builtin_hint_processor::builtin_hint_processor_definition::{
                 BuiltinHintProcessor, HintProcessorData,
@@ -309,7 +310,6 @@ mod test {
             relocatable::{MaybeRelocatable, Relocatable},
         },
     };
-    use felt::{Felt, NewFelt};
     use num_bigint::BigInt;
     use pyo3::{PyObject, Python, ToPyObject};
     use std::{any::Any, collections::HashMap, rc::Rc};

--- a/src/vm_core.rs
+++ b/src/vm_core.rs
@@ -191,10 +191,12 @@ impl PyVM {
                 {
                     let hint_data = hint_data
                         .downcast_ref::<HintProcessorData>()
-                        .ok_or(VirtualMachineError::Hint(
-                            hint_index,
-                            Box::new(HintError::WrongHintData),
-                        ))
+                        .ok_or_else(|| {
+                            VirtualMachineError::Hint(
+                                hint_index,
+                                Box::new(HintError::WrongHintData),
+                            )
+                        })
                         .map_err(to_py_error)?;
 
                     if let Err(hint_error) = self.execute_hint(

--- a/src/vm_core.rs
+++ b/src/vm_core.rs
@@ -93,7 +93,6 @@ impl PyVM {
         static_locals: Option<&HashMap<String, PyObject>>,
     ) -> Result<(), PyErr> {
         Python::with_gil(|py| -> Result<(), PyErr> {
-            println!("Excecuting Hint: {}", hint_data.code);
             let memory = PyMemory::new(self);
             let segments = PySegmentManager::new(self, memory.clone());
             let ap = PyRelocatable::from((*self.vm).borrow().get_ap());


### PR DESCRIPTION
Updates cairo-rs version to match the current last commit in cairo-rs

Most notable changes in cairo-rs:

- new error type HintError

- new type Felt

- cairo-rs crate name changed to cairo-vm

Other changes in cairo-rs-py:

- Swap BigInt for BigUint