### PR TITLE
Update cairo-rs version after `BuiltinRunner::final_stack` fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,8 +131,8 @@ checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 
 [[package]]
 name = "cairo-felt"
-version = "0.1.1"
-source = "git+https://github.com/lambdaclass/cairo-rs.git?rev=8ce89046a295ee08e0d1d80c0b679c3faa765f1c#8ce89046a295ee08e0d1d80c0b679c3faa765f1c"
+version = "0.1.3"
+source = "git+https://github.com/lambdaclass/cairo-rs.git?rev=195f9ce1eaaa66093207078525e5158e78ce0590#195f9ce1eaaa66093207078525e5158e78ce0590"
 dependencies = [
  "lazy_static",
  "num-bigint",
@@ -155,8 +155,8 @@ dependencies = [
 
 [[package]]
 name = "cairo-vm"
-version = "0.1.2"
-source = "git+https://github.com/lambdaclass/cairo-rs.git?rev=8ce89046a295ee08e0d1d80c0b679c3faa765f1c#8ce89046a295ee08e0d1d80c0b679c3faa765f1c"
+version = "0.1.3"
+source = "git+https://github.com/lambdaclass/cairo-rs.git?rev=195f9ce1eaaa66093207078525e5158e78ce0590#195f9ce1eaaa66093207078525e5158e78ce0590"
 dependencies = [
  "bincode",
  "cairo-felt",
@@ -590,7 +590,7 @@ dependencies = [
 [[package]]
 name = "parse-hyperlinks"
 version = "0.23.4"
-source = "git+https://github.com/lambdaclass/cairo-rs.git?rev=8ce89046a295ee08e0d1d80c0b679c3faa765f1c#8ce89046a295ee08e0d1d80c0b679c3faa765f1c"
+source = "git+https://github.com/lambdaclass/cairo-rs.git?rev=195f9ce1eaaa66093207078525e5158e78ce0590#195f9ce1eaaa66093207078525e5158e78ce0590"
 dependencies = [
  "nom",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,8 +131,8 @@ checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 
 [[package]]
 name = "cairo-felt"
-version = "0.1.0"
-source = "git+https://github.com/lambdaclass/cairo-rs.git?rev=75bfba3850194a270d270e80ea57d39235690edd#75bfba3850194a270d270e80ea57d39235690edd"
+version = "0.1.1"
+source = "git+https://github.com/lambdaclass/cairo-rs.git?rev=8ce89046a295ee08e0d1d80c0b679c3faa765f1c#8ce89046a295ee08e0d1d80c0b679c3faa765f1c"
 dependencies = [
  "lazy_static",
  "num-bigint",
@@ -155,8 +155,8 @@ dependencies = [
 
 [[package]]
 name = "cairo-vm"
-version = "0.1.1"
-source = "git+https://github.com/lambdaclass/cairo-rs.git?rev=75bfba3850194a270d270e80ea57d39235690edd#75bfba3850194a270d270e80ea57d39235690edd"
+version = "0.1.2"
+source = "git+https://github.com/lambdaclass/cairo-rs.git?rev=8ce89046a295ee08e0d1d80c0b679c3faa765f1c#8ce89046a295ee08e0d1d80c0b679c3faa765f1c"
 dependencies = [
  "bincode",
  "cairo-felt",
@@ -590,7 +590,7 @@ dependencies = [
 [[package]]
 name = "parse-hyperlinks"
 version = "0.23.4"
-source = "git+https://github.com/lambdaclass/cairo-rs.git?rev=75bfba3850194a270d270e80ea57d39235690edd#75bfba3850194a270d270e80ea57d39235690edd"
+source = "git+https://github.com/lambdaclass/cairo-rs.git?rev=8ce89046a295ee08e0d1d80c0b679c3faa765f1c#8ce89046a295ee08e0d1d80c0b679c3faa765f1c"
 dependencies = [
  "nom",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 
 [dependencies]
 pyo3 = { version = "0.16.5", features = ["num-bigint"] }
-cairo-vm = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "75bfba3850194a270d270e80ea57d39235690edd" }
-cairo-felt = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "75bfba3850194a270d270e80ea57d39235690edd" }
+cairo-vm = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "8ce89046a295ee08e0d1d80c0b679c3faa765f1c" }
+cairo-felt = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "8ce89046a295ee08e0d1d80c0b679c3faa765f1c" }
 num-bigint = "0.4"
 lazy_static = "1.4.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-pyo3 = { version = "0.16.5", features = ["num-bigint"] }
+pyo3 = { version = "0.18", features = ["num-bigint"] }
 cairo-vm = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "195f9ce1eaaa66093207078525e5158e78ce0590" }
 cairo-felt = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "195f9ce1eaaa66093207078525e5158e78ce0590" }
 num-bigint = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 
 [dependencies]
 pyo3 = { version = "0.16.5", features = ["num-bigint"] }
-cairo-vm = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "8ce89046a295ee08e0d1d80c0b679c3faa765f1c" }
-cairo-felt = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "8ce89046a295ee08e0d1d80c0b679c3faa765f1c" }
+cairo-vm = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "195f9ce1eaaa66093207078525e5158e78ce0590" }
+cairo-felt = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "195f9ce1eaaa66093207078525e5158e78ce0590" }
 num-bigint = "0.4"
 lazy_static = "1.4.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 pyo3 = { version = "0.16.5", features = ["num-bigint"] }
 cairo-vm = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "195f9ce1eaaa66093207078525e5158e78ce0590" }
 cairo-felt = { git = "https://github.com/lambdaclass/cairo-rs.git", rev = "195f9ce1eaaa66093207078525e5158e78ce0590" }
-
 num-bigint = "0.4"
 lazy_static = "1.4.0"
 

--- a/src/cairo_runner.rs
+++ b/src/cairo_runner.rs
@@ -30,7 +30,7 @@ use pyo3::{
     prelude::*,
     types::PyIterator,
 };
-use std::{any::Any, borrow::BorrowMut, collections::HashMap, iter::zip, path::PathBuf, rc::Rc};
+use std::{any::Any, borrow::BorrowMut, collections::HashMap, path::PathBuf, rc::Rc};
 
 pyo3::import_exception!(starkware.cairo.lang.vm.utils, ResourcesError);
 
@@ -275,35 +275,14 @@ impl PyCairoRunner {
     }
 
     pub fn get_builtins_final_stack(&self, stack_ptr: PyRelocatable) -> PyResult<PyRelocatable> {
-        let mut stack_ptr = Relocatable::from(&stack_ptr);
-        let mut stop_ptrs = Vec::new();
-        let mut stop_ptr;
-
-        for (_, runner) in self
-            .pyvm
-            .vm
-            .borrow()
-            .get_builtin_runners()
-            .iter()
-            .rev()
-            .filter(|(builtin_name, _builtin_runner)| {
-                self.inner.get_program_builtins().contains(builtin_name)
-            })
-        {
-            (stack_ptr, stop_ptr) = runner
-                .final_stack(&self.pyvm.vm.borrow(), stack_ptr)
-                .map_err(to_py_error)?;
-            stop_ptrs.push(stop_ptr);
-        }
-
-        for ((_, runner), stop_ptr) in zip(
-            (*self.pyvm.vm).borrow_mut().get_builtin_runners_as_mut(),
-            stop_ptrs,
-        ) {
-            runner.set_stop_ptr(stop_ptr);
-        }
-
-        Ok(stack_ptr.into())
+        Ok(self
+            .inner
+            .get_builtins_final_stack(
+                &mut (*self.pyvm.vm).borrow_mut(),
+                Relocatable::from(&stack_ptr),
+            )
+            .map_err(to_py_error)?
+            .into())
     }
 
     pub fn get_execution_resources(&self) -> PyResult<PyExecutionResources> {
@@ -688,7 +667,7 @@ mod test {
     use super::*;
     use crate::biguint;
     use crate::relocatable::PyMaybeRelocatable::RelocatableValue;
-    use cairo_felt::{Felt, NewFelt};
+    use cairo_felt::Felt;
     use num_bigint::BigUint;
     use std::env::temp_dir;
     use std::fs;

--- a/src/cairo_runner.rs
+++ b/src/cairo_runner.rs
@@ -125,10 +125,14 @@ impl PyCairoRunner {
                 &mut self.hint_processor,
             )
             .map_err(to_py_error)?;
-
         (*self.pyvm.vm)
-            .borrow_mut()
+            .borrow()
             .verify_auto_deductions()
+            .map_err(to_py_error)?;
+        self.inner
+            .read_return_values(&mut (*self.pyvm.vm).borrow_mut())
+            .map_err(to_py_error)?;
+        verify_secure_runner(&self.inner, true, &mut (*self.pyvm.vm).borrow_mut())
             .map_err(to_py_error)?;
 
         self.relocate()?;

--- a/src/ecdsa.rs
+++ b/src/ecdsa.rs
@@ -126,40 +126,6 @@ mod test {
     }
 
     #[test]
-    fn update_py_signature_with_invalid_vaue() {
-        let rel = PyRelocatable {
-            segment_index: 2,
-            offset: 0,
-        };
-
-        let numbers = (
-            BigUint::new(vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
-            BigUint::new(vec![1, 0, 0, 0, 0, 0, 17, 134217728]),
-        );
-
-        let mut signature = PySignature::new();
-
-        signature.add_signature(rel, numbers);
-
-        let path = "cairo_programs/ecdsa.json".to_string();
-        let program = fs::read_to_string(path).unwrap();
-        let mut runner = PyCairoRunner::new(
-            program,
-            Some("main".to_string()),
-            Some("all".to_string()),
-            false,
-        )
-        .unwrap();
-
-        runner.initialize().expect("Failed to initialize VM");
-
-        let mut binding = runner.pyvm.vm.borrow_mut();
-        let signature_builtin = binding.get_signature_builtin().unwrap();
-
-        assert!(signature.update_signature(signature_builtin).is_err());
-    }
-
-    #[test]
     fn py_signature_to_py_object() {
         let new_py_signature = PySignature::new();
 

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -1,5 +1,5 @@
 use crate::utils::const_path_to_const_name;
-use cairo_felt::{Felt, FeltOps};
+use cairo_felt::Felt;
 use num_bigint::BigUint;
 use pyo3::exceptions::PyValueError;
 use std::{
@@ -275,7 +275,7 @@ pub fn compute_addr_from_reference(
 #[cfg(test)]
 mod tests {
     use crate::{memory::PyMemory, relocatable::PyRelocatable};
-    use cairo_felt::NewFelt;
+
     use cairo_vm::types::{instruction::Register, relocatable::MaybeRelocatable};
     use pyo3::{types::PyDict, PyCell};
 

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -3,7 +3,7 @@ use crate::{
     utils::to_py_error,
     vm_core::PyVM,
 };
-use cairo_felt::FeltOps;
+
 use cairo_vm::{
     types::relocatable::{MaybeRelocatable, Relocatable},
     vm::vm_core::VirtualMachine,

--- a/src/memory_segments.rs
+++ b/src/memory_segments.rs
@@ -98,7 +98,7 @@ impl PySegmentManager {
 mod test {
     use super::PySegmentManager;
     use crate::{memory::PyMemory, relocatable::PyMaybeRelocatable, vm_core::PyVM};
-    use cairo_felt::{Felt, NewFelt};
+    use cairo_felt::Felt;
     use cairo_vm::types::relocatable::{MaybeRelocatable, Relocatable};
     use pyo3::{Python, ToPyObject};
 

--- a/src/range_check.rs
+++ b/src/range_check.rs
@@ -2,7 +2,6 @@ use cairo_vm::vm::{
     errors::vm_errors::VirtualMachineError, runners::builtin_runner::RangeCheckBuiltinRunner,
 };
 
-use cairo_felt::FeltOps;
 use num_bigint::BigUint;
 use pyo3::prelude::*;
 

--- a/src/relocatable.rs
+++ b/src/relocatable.rs
@@ -195,7 +195,7 @@ impl From<&BigUint> for PyMaybeRelocatable {
         PyMaybeRelocatable::Int(if val < &CAIRO_PRIME {
             val.clone()
         } else {
-            val % CAIRO_PRIME.clone()
+            val % &*CAIRO_PRIME
         })
     }
 }
@@ -205,7 +205,7 @@ impl From<BigUint> for PyMaybeRelocatable {
         PyMaybeRelocatable::Int(if val < *CAIRO_PRIME {
             val
         } else {
-            val % CAIRO_PRIME.clone()
+            val % &*CAIRO_PRIME
         })
     }
 }

--- a/src/relocatable.rs
+++ b/src/relocatable.rs
@@ -2,7 +2,7 @@ use crate::{
     biguint,
     utils::{biguint_to_usize, to_py_error},
 };
-use cairo_felt::FeltOps;
+
 use cairo_vm::{
     types::relocatable::{MaybeRelocatable, Relocatable},
     vm::errors::vm_errors::VirtualMachineError,

--- a/src/relocatable.rs
+++ b/src/relocatable.rs
@@ -1,6 +1,7 @@
 use crate::{
     biguint,
     utils::{biguint_to_usize, to_py_error},
+    vm_core::CAIRO_PRIME,
 };
 
 use cairo_vm::{
@@ -191,13 +192,21 @@ impl From<PyRelocatable> for PyMaybeRelocatable {
 
 impl From<&BigUint> for PyMaybeRelocatable {
     fn from(val: &BigUint) -> Self {
-        PyMaybeRelocatable::Int(val.clone())
+        PyMaybeRelocatable::Int(if val < &CAIRO_PRIME {
+            val.clone()
+        } else {
+            val % CAIRO_PRIME.clone()
+        })
     }
 }
 
 impl From<BigUint> for PyMaybeRelocatable {
     fn from(val: BigUint) -> Self {
-        PyMaybeRelocatable::Int(val)
+        PyMaybeRelocatable::Int(if val < *CAIRO_PRIME {
+            val
+        } else {
+            val % CAIRO_PRIME.clone()
+        })
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,4 @@
-use cairo_felt::{Felt, FeltOps};
+use cairo_felt::Felt;
 use cairo_vm::vm::errors::vm_errors::VirtualMachineError;
 use num_bigint::BigUint;
 use pyo3::{exceptions::PyValueError, PyErr};

--- a/src/vm_core.rs
+++ b/src/vm_core.rs
@@ -9,7 +9,7 @@ use crate::{
     memory::PyMemory, memory_segments::PySegmentManager, range_check::PyRangeCheck,
     relocatable::PyRelocatable,
 };
-use cairo_felt::{Felt, FIELD};
+use cairo_felt::{Felt, FIELD_HIGH, FIELD_LOW};
 use cairo_vm::any_box;
 use cairo_vm::hint_processor::hint_processor_definition::HintProcessor;
 use cairo_vm::serde::deserialize_program::Member;
@@ -52,7 +52,7 @@ const GLOBAL_NAMES: [&str; 18] = [
 
 lazy_static! {
     pub static ref CAIRO_PRIME: BigUint =
-        (Into::<BigUint>::into(FIELD.0) << 128) + Into::<BigUint>::into(FIELD.1);
+        (Into::<BigUint>::into(FIELD_LOW) << 128) + Into::<BigUint>::into(FIELD_HIGH);
 }
 
 #[derive(Clone)]
@@ -298,7 +298,7 @@ pub(crate) fn update_scope_hint_locals(
 mod test {
     use super::*;
     use crate::{biguint, relocatable::PyMaybeRelocatable, vm_core::PyVM};
-    use cairo_felt::{Felt, NewFelt};
+    use cairo_felt::Felt;
     use cairo_vm::{
         hint_processor::{
             builtin_hint_processor::builtin_hint_processor_definition::{

--- a/src/vm_core.rs
+++ b/src/vm_core.rs
@@ -52,7 +52,7 @@ const GLOBAL_NAMES: [&str; 18] = [
 
 lazy_static! {
     pub static ref CAIRO_PRIME: BigUint =
-        (Into::<BigUint>::into(FIELD_LOW) << 128) + Into::<BigUint>::into(FIELD_HIGH);
+        (Into::<BigUint>::into(FIELD_HIGH) << 128) + Into::<BigUint>::into(FIELD_LOW);
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
Depends on https://github.com/lambdaclass/cairo-rs/pull/780
- [x] Updated Cargo.toml after merge: DONT MERGE till this box is ticked
- Remove now-impossible test case
- Add `verify_secure_runner` call to `cairo_run_py` (This solves Issue #216) 
Note: The test I removed only fails when `SignatureBuiltinRunner::add_signature` fails to convert a Felt into a FieldElement. This used to happen when the Felt was equal to cairo's prime. This no longer happens as Felt::from now returns Felt::zero when the value is equal to CAIRO_PRIME (PR https://github.com/lambdaclass/cairo-rs/pull/743)